### PR TITLE
RXR-252: Remove download argument to read_who_table()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clinPK
 Type: Package
 Title: Clinical Pharmacokinetics Toolkit
-Version: 0.10.2
+Version: 0.10.3
 Date: 2021-05-19
 Authors@R: c(person("Ron", "Keizer", email = "ron@insight-rx.com", role
         = "aut"), person("Jasmine", "Hughes", email =

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clinPK
 Type: Package
 Title: Clinical Pharmacokinetics Toolkit
-Version: 0.10.3
+Version: 0.10.4
 Date: 2021-05-19
 Authors@R: c(person("Ron", "Keizer", email = "ron@insight-rx.com", role
         = "aut"), person("Jasmine", "Hughes", email =
@@ -16,7 +16,6 @@ Description: Calculates equations commonly used in clinical
         chemistry, and conversion of common clinical parameters. Where
         possible and relevant, it provides multiple published and
         peer-reviewed equations within the respective R function.
-Imports: curl
 License: MIT + file LICENSE
 LazyData: TRUE
 RoxygenNote: 7.1.1

--- a/R/pct_for_age_generic.R
+++ b/R/pct_for_age_generic.R
@@ -29,7 +29,7 @@ pct_for_age_generic <- function(age = NULL, value = NULL, sex = NULL, variable="
     type <- "wfa"
   }
   
-  dat <- read_who_table(sex=sex, age=age, type=type, download=FALSE)
+  dat <- read_who_table(sex=sex, age=age, type=type)
   tmp <- dat[which.min(abs(age - dat$age)),-(1:4)]
   pct <- as.list(tmp)
   if(!is.null(value)) {

--- a/R/read_who_table.R
+++ b/R/read_who_table.R
@@ -1,17 +1,22 @@
-#' Internal function to read WHO growth tables from package or download from WHO
+#' Read WHO growth tables
+#'
+#' Provides a data frame of the WHO growth table for a given age, sex, and type
+#' of measurement.
+#'
+#' This function uses files included in `system.file(package = "clinPK")`.
+#' Previously this function also gave the option to download the tables from
+#' WHO, but the original URL ("http://www.who.int/entity/childgrowth/standards")
+#' no longer exists as of 2021-05-19.
 #'
 #' @param sex, either `male` or `female`
 #' @param age age in years
 #' @param type table type, choose from `wfa` (weight for age), `lhfa` (length for age)
-#' @param who_url base URL for WHO growth tables
-#' @param download download current tables from WHO?
 #' @export
+#' @md
 read_who_table <- function(
   sex = NULL,
   age = NULL,
-  type = "wfa",
-  who_url = "http://www.who.int/entity/childgrowth/standards",
-  download = FALSE
+  type = "wfa"
 ) {
   if(is.null(age)) {
     stop("Age required!")
@@ -30,26 +35,14 @@ read_who_table <- function(
     }
     
     who_file <- paste0(type, '_', str_sex, '_', postfix,'.txt')
-    if(!download) {
-      # use tables supplied with package (also from WHO)
-      dat <- data.frame(read.table(file=paste0(system.file(package='clinPK'),'/', who_file), 
-                                   sep = "\t", header = TRUE))
-    } else {
-      cat("Downloading data from WHO...")
-      con <- curl::curl(paste0(who_url, "/", who_file))
-      open(con)
-      tmp <- readLines(con)
-      close(con)
-      cat("done.")
-      dat <- c()
-      cnam <- strsplit(tmp[1], "\t")[[1]]
-      tmp <- tmp[-1]
-      for(i in seq(tmp)) {
-        dat <- rbind(dat, as.num(unlist(strsplit(tmp[i], "\t"))))
-      }
-      dat <- data.frame(dat)
-      colnames(dat) <- cnam
-    }
+    # use tables supplied with package (from WHO)
+    dat <- data.frame(
+      read.table(
+        file = paste0(system.file(package = 'clinPK'), '/', who_file),
+        sep = "\t",
+        header = TRUE
+      )
+    )
     dat[,1] <- dat[,1]/unit # convert to years
     colnames(dat)[1] <- "age"
     if("StDev" %in% names(dat)) {

--- a/man/read_who_table.Rd
+++ b/man/read_who_table.Rd
@@ -2,27 +2,24 @@
 % Please edit documentation in R/read_who_table.R
 \name{read_who_table}
 \alias{read_who_table}
-\title{Internal function to read WHO growth tables from package or download from WHO}
+\title{Read WHO growth tables}
 \usage{
-read_who_table(
-  sex = NULL,
-  age = NULL,
-  type = "wfa",
-  who_url = "http://www.who.int/entity/childgrowth/standards",
-  download = FALSE
-)
+read_who_table(sex = NULL, age = NULL, type = "wfa")
 }
 \arguments{
-\item{sex, }{either `male` or `female`}
+\item{sex, }{either \code{male} or \code{female}}
 
 \item{age}{age in years}
 
-\item{type}{table type, choose from `wfa` (weight for age), `lhfa` (length for age)}
-
-\item{who_url}{base URL for WHO growth tables}
-
-\item{download}{download current tables from WHO?}
+\item{type}{table type, choose from \code{wfa} (weight for age), \code{lhfa} (length for age)}
 }
 \description{
-Internal function to read WHO growth tables from package or download from WHO
+Provides a data frame of the WHO growth table for a given age, sex, and type
+of measurement.
+}
+\details{
+This function uses files included in \code{system.file(package = "clinPK")}.
+Previously this function also gave the option to download the tables from
+WHO, but the original URL ("http://www.who.int/entity/childgrowth/standards")
+no longer exists as of 2021-05-19.
 }

--- a/tests/testthat/test_read_who_table.R
+++ b/tests/testthat/test_read_who_table.R
@@ -1,0 +1,39 @@
+test_that("Table is returned", {
+  dat1 <- read_who_table(sex = "male", age = 10, type = "wfa")
+  dat2 <- read_who_table(sex = "female", age = 3, type = "lhfa")
+  expect_true(inherits(dat1, "data.frame"))
+  expect_true(nrow(dat1) > 0)
+  expect_true(inherits(dat2, "data.frame"))
+  expect_true(nrow(dat2) > 0)
+  expected_names <- c(
+    "age",
+    "L",
+    "M",
+    "S",
+    "P01",
+    "P1",
+    "P3",
+    "P5",
+    "P10",
+    "P15",
+    "P25",
+    "P50",
+    "P75",
+    "P85",
+    "P90",
+    "P95",
+    "P97",
+    "P99",
+    "P999"
+  )
+  expect_equal(names(dat1), expected_names)
+  expect_equal(names(dat2), expected_names)
+})
+
+test_that("read_who_table errors if no age provided", {
+  expect_error(read_who_table(sex = "male", type = "wfa"))
+})
+
+test_that("read_who_table errors if table type not recognized", {
+  expect_error(read_who_table(sex = "male", age = 10, type = "not a table"))
+})


### PR DESCRIPTION
Removes the `download` and `who_url` arguments to `read_who_table()` since the tables are no longer found there. 
Also added some tests for `read_who_table()` since it did not have any.

In `pct_for_age_generic()` we were specifying `download = FALSE` so I removed that. I checked insightrxr and didn't find any places where we were using the argument there, but if we wanted to be extra safe we could keep the argument names, but have them throw a warning and fall back to the packaged datasets.
