### PR TITLE
RXR-374: Support grams as input unit in weight2kg

### DIFF
--- a/R/weight2kg.R
+++ b/R/weight2kg.R
@@ -1,7 +1,7 @@
 #' Convert any weight unit to kg
 #'
 #' @param value weight in any allowed unit
-#' @param unit unit of weight, one of "lbs", "pound", "pounds", "oz", "ounce", "ounces"
+#' @param unit unit of weight, one of "lbs", "pound", "pounds", "oz", "ounce", "ounces", "g", "gram", "grams"
 #' @examples
 #' weight2kg(250, unit = "oz")
 #' weight2kg(250, unit = "pounds")
@@ -12,12 +12,15 @@ weight2kg <- function(value = NULL, unit = NULL) {
     stop("No weight value specified.")
   }
   if(!is.null(unit) && !is.na(unit)) {
-    if(tolower(unit) %in% c("kg", "lbs", "pound", "pounds", "oz", "ounce", "ounces")) {
+    if(tolower(unit) %in% c("kg", "lbs", "pound", "pounds", "oz", "ounce", "ounces", "g", "gram", "grams")) {
       if(tolower(unit) %in% c("lbs", "pound", "pounds")) {
         value <- value / 2.20462
       }
       if(tolower(unit) %in% c("oz", "ounce", "ounces")) {
         value <- value / 35.274
+      }
+      if (tolower(unit) %in% c("g", "gram", "grams")) {
+        value <- value / 1000
       }
     } else {
       warning(paste0("Unit (", unit,") not recognized, returning original weight."))

--- a/man/weight2kg.Rd
+++ b/man/weight2kg.Rd
@@ -9,7 +9,7 @@ weight2kg(value = NULL, unit = NULL)
 \arguments{
 \item{value}{weight in any allowed unit}
 
-\item{unit}{unit of weight, one of "lbs", "pound", "pounds", "oz", "ounce", "ounces"}
+\item{unit}{unit of weight, one of "lbs", "pound", "pounds", "oz", "ounce", "ounces", "g", "gram", "grams"}
 }
 \description{
 Convert any weight unit to kg

--- a/tests/testthat/test_weight2kg.R
+++ b/tests/testthat/test_weight2kg.R
@@ -34,3 +34,7 @@ test_that("vectorized input works", {
     c(4.0823362, 4.5359291)
   )
 })
+
+test_that("weight2kg supports grams as input unit", {
+  expect_equal(weight2kg(1000, "g"), 1)
+})


### PR DESCRIPTION
Allows `weight2kg()` to convert grams to kg.