### PR TITLE
RXR-405: Remove ability to round in `calc_ibw()`

### DIFF
--- a/R/calc_ibw.R
+++ b/R/calc_ibw.R
@@ -34,7 +34,6 @@
 #' @param method_adults method to use for >=18 years. Currently `"devine"` is
 #'   the only method that is supported (Devine BJ. Drug Intell Clin Pharm.
 #'   1974;8:650-655).
-#' @param digits number of decimals (can be NULL to for no rounding)
 #' @examples
 #' calc_ibw(weight = 70, height = 170, age = 40, sex = "female")
 #' calc_ibw(weight = 30, height = 140, age = 10, sex = "female")
@@ -45,8 +44,7 @@ calc_ibw <- function (
   age = NULL,
   sex = "male",
   method_children = "standard",
-  method_adults = "devine",
-  digits = NULL
+  method_adults = "devine"
 ) {
   method_children <- match.arg(method_children)
   method_adults <- match.arg(method_adults)
@@ -79,10 +77,6 @@ calc_ibw <- function (
       method_adults,
       "devine" = ibw_devine(age = age, height = height, sex = sex)
     )
-  }
-
-  if (!is.null(digits)) {
-    ibw <- round(ibw, digits = digits)
   }
 
   return(ibw)

--- a/man/calc_ibw.Rd
+++ b/man/calc_ibw.Rd
@@ -10,8 +10,7 @@ calc_ibw(
   age = NULL,
   sex = "male",
   method_children = "standard",
-  method_adults = "devine",
-  digits = NULL
+  method_adults = "devine"
 )
 }
 \arguments{
@@ -29,8 +28,6 @@ calc_ibw(
 \item{method_adults}{method to use for >=18 years. Currently `"devine"` is
 the only method that is supported (Devine BJ. Drug Intell Clin Pharm.
 1974;8:650-655).}
-
-\item{digits}{number of decimals (can be NULL to for no rounding)}
 }
 \description{
 Get an estimate of ideal body weight. This function allows several commonly used equations

--- a/tests/testthat/test_calc_ibw.R
+++ b/tests/testthat/test_calc_ibw.R
@@ -30,13 +30,6 @@ test_that("calc_ibw() uses weight when age < 1", {
   )
 })
 
-test_that("calc_ibw() can round output", {
-  expect_equal(
-    calc_ibw(age = 40, height = 180, sex = "female", digits = 1),
-    70.5
-  )
-})
-
 test_that("ibw_standard only supports children and requires age", {
   expect_error(ibw_standard(age = 25))
   expect_error(ibw_standard(age = NULL))


### PR DESCRIPTION
Removes `calc_ibw()`'s `digits` argument; users should round output separately if needed.