### PR TITLE
RXR-373: consistent handling of missing/unrecognized data in `calc_ibw()`/`calc_ffm()`/`calc_egfr()`.

### DIFF
--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -469,22 +469,16 @@ egfr_bedside_schwartz <- function(age, height, scr, verbose) {
 
 #' @rdname calc_egfr
 egfr_schwartz <- function(age, preterm, sex, height, scr) {
-  if (!sex %in% c("male", "female")) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
+  if (age < 1 ) {
+    k <- ifelse(preterm, 0.33, 0.45)
+  } else if (age > 13) {
+    if (!sex %in% c("male", "female")) {
+      warning("This method requires sex to be one of 'male' or 'female'.")
+      return(NULL)
+    }
+    k <- ifelse(sex == 'male', 0.7,  0.55)
+  } else {
+    k <- 0.55
   }
-  k <- ifelse(
-    preterm & age < 1,
-    0.33,
-    ifelse(
-      age < 1,
-      0.45,
-      ifelse(
-        age > 13 & sex == 'male',
-        0.7,
-        0.55
-      )
-    )
-  )
   (k * height) / scr
 }

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -281,6 +281,21 @@ calc_egfr <- function (
   # -------------
   unit <- tolower(unit_out)
 
+  if (is.null(crcl)) {
+    return(
+      list(
+        value = crcl,
+        age = age,
+        bsa = bsa,
+        sex = sex,
+        scr = scr,
+        unit = unit,
+        weight = weight_for_egfr,
+        capped = list()
+      )
+    )
+  }
+
   # --- Convert to relative if required
   if (!relative & !grepl('cockcroft_gault', method)) {
     crcl <- relative2absolute_bsa(crcl, bsa)[["value"]]

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -72,7 +72,7 @@
 #' calc_egfr(sex = "male", age = 50, scr = c(1.1, 0.8),
 #'   weight = 70, height = 170, method = "jelliffe_unstable")
 #' calc_egfr(sex = "male", age = 50, scr = 1.1,
-#'   weight = 70, bsa = 1.6, method = "malmo_lund_rev", relative = FALSE)
+#'   weight = 70, bsa = 1.6, method = "malmo_lund_revised", relative = FALSE)
 #' @export
 calc_egfr <- function (
   method = "cockcroft_gault",
@@ -191,90 +191,91 @@ calc_egfr <- function (
 
   # Calculate eGFR
   # --------------
-  crcl <- c()
-  if (method == 'wright'){
-    crcl <- ((74.4344 - (0.438914 * age)) * bsa * (1-(0.168*ifelse(sex == "male", 0, 1))))/scr
 
-  } else if (method == "jelliffe") {
-    crcl <- ((98 - 0.8*(age - 20)) * (1 - 0.01 * ifelse(sex == "male", 0, 1)) * bsa/1.73) / scr
-
-  } else if (method == "jelliffe_unstable") {
-    vol <- 4 * weight
-
-    # for times, if null or negative or mismatch in times/scr length, assume one day difference
-    # otherwise, ensure times and scrs are sequential.
-    if (is.null(times) | length(scr) != length(times)) {
-      dt <- rep(1, length(scr))
-    } else {
-      scr <- scr[order(times)]
-      times <- sort(times)
-      dt <- c(1, diff(times))
-    }
-
-    # for first creatinine, use that value. for subsequent creatinines, use average of current and previous values.
-    if (length(scr) == 1) {
-      scr_diff <- 0
-      scr_av <- scr
-    } else {
-      scr_diff <- c(0, diff(scr)) * -1
-      scr_av <- scr + scr_diff/2
-    }
-
-    # calculate creatinine production
-    cr_prod <- (29.305-(0.203 * age)) * weight * (1.037-(0.0338 * scr_av)) * ifelse(sex == "male", 0.85, 0.765)
-    # calculate crcl
-    crcl <- ((vol * scr_diff/dt + cr_prod) * 100) / (1440 * scr_av)
-
-  } else if (method == "mdrd") {
-    f_sex <- ifelse(sex == 'female', 0.762, 1)
-    f_race <- ifelse(race == 'black', 1.21, 1)
-    crcl <- 186 * scr^(-1.154) * f_sex * f_race * age^(-0.203)
-    
-  } else if (method == "mdrd_ignore_race") {
-    f_sex <- ifelse(sex == 'female', 0.762, 1)
-    crcl <- 186 * scr^(-1.154) * f_sex * age^(-0.203)
-
-  } else if (method == "ckd_epi"){
-    f_sex <- ifelse(sex == 'female', 1.018, 1)
-    f_race <- ifelse(race == 'black', 1.159, 1)
-    crcl <- 141 * (scr ^ ifelse(scr < 1, -0.329, -1.209)) * 0.993^age * f_sex * f_race
-    
-  } else if (method == "ckd_epi_ignore_race"){
-    f_sex <- ifelse(sex == 'female', 1.018, 1)
-    crcl <- 141 * (scr ^ ifelse(scr < 1, -0.329, -1.209)) * 0.993^age * f_sex
-
-  } else if (method == 'cockcroft_gault_sci') {
-    f_sex <- ifelse(sex == 'female', 0.85, 1)
-    crcl <- 2.3 * (f_sex * (140-age) / scr * (weight/72)) ^0.7
-
-  } else if (grepl('cockcroft_gault', method)) {
-    f_sex <- ifelse(sex == 'female', 0.85, 1)
-    crcl <- f_sex * (140-age) / scr * (weight/72)
-
-  } else if (grepl('malmo', method) & grepl('lund', method)) {
-    scr_cutoff <- ifelse(sex == 'female', 1.696833, 2.0362)
-    intercept <- ifelse(sex == 'female', 2.5, 2.56)
-    slope <- ifelse(scr >= scr_cutoff, -0.926,
-                    ifelse(sex == 'female', 1.06964, 0.855712))
-    cr_term <- ifelse(scr < scr_cutoff, scr_cutoff - scr, log(scr/scr_cutoff))
-    x <- intercept + slope * cr_term
-
-    crcl <- exp(x - 0.0158*age + 0.438*log(age))
-
-  } else if (method %in% c("bedside_schwartz", "schwartz_revised")) {
-    if(age < 1 && verbose) message("This equation is not meant for patients < 1 years of age.")
-    k <- 0.413
-    crcl <- (k * height) / scr
-
-  } else if (method == 'schwartz') {
-    k <- ifelse(preterm & age < 1, 0.33,
-                ifelse(age < 1, 0.45,
-                       ifelse(age > 13 & sex == 'male', 0.7,
-                               0.55)))
-    crcl <- (k * height) / scr
-  } else {
-    return(FALSE)
+  if (grepl("cockcroft_gault(.*)(?<!sci)$", method, perl = TRUE)) {
+    method <- "cockcroft_gault"
   }
+  if (grepl("malmo", method) & grepl("lund", method)) {
+    method <- "malmo_lund_revised"
+  }
+
+  crcl <- switch(
+    method,
+    "wright" = egfr_wright(age = age, bsa = bsa, sex = sex, scr = scr),
+    "jelliffe" = egfr_jelliffe(age = age, sex = sex, bsa = bsa, scr = scr),
+    "jelliffe_unstable" = egfr_jelliffe_unstable(
+      weight = weight,
+      times = times,
+      scr = scr,
+      age = age,
+      sex = sex
+    ),
+    "mdrd" = egfr_mdrd(
+      sex = sex,
+      race = race,
+      scr = scr,
+      age = age,
+      use_race = TRUE
+    ),
+    "mdrd_ignore_race" = egfr_mdrd(
+      sex = sex,
+      race = race,
+      scr = scr,
+      age = age,
+      use_race = FALSE
+    ),
+    "ckd_epi" = egfr_ckd_epi(
+      sex = sex,
+      race = race,
+      scr = scr,
+      age = age,
+      use_race = TRUE
+    ),
+    "ckd_epi_ignore_race" = egfr_ckd_epi(
+      sex = sex,
+      race = race,
+      scr = scr,
+      age = age,
+      use_race = FALSE
+    ),
+    "cockcroft_gault_sci" = egfr_cockcroft_gault_sci(
+      sex = sex,
+      age = age,
+      scr = scr,
+      weight = weight
+    ),
+    "cockcroft_gault" = egfr_cockcroft_gault(
+      sex = sex,
+      age = age,
+      scr = scr,
+      weight = weight
+    ),
+    "malmo_lund_revised" = egfr_malmo_lund(
+      sex = sex,
+      age = age,
+      scr = scr
+    ),
+    "bedside_schwartz" = egfr_bedside_schwartz(
+      age = age,
+      height = height,
+      scr = scr,
+      verbose = verbose
+    ),
+    "schwartz_revised" = egfr_bedside_schwartz(
+      age = age,
+      height = height,
+      scr = scr,
+      verbose = verbose
+    ),
+    "schwartz" = egfr_schwartz(
+      age = age,
+      preterm = preterm,
+      sex = sex,
+      height = height,
+      scr = scr
+    ),
+    FALSE
+  )
 
   # Format Output
   # -------------
@@ -329,4 +330,144 @@ calc_egfr <- function (
     weight = weight_for_egfr,
     capped = capped
   ))
+}
+
+#' @rdname calc_egfr
+egfr_wright <- function(age, bsa, sex, scr) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  ((74.4344 - (0.438914 * age)) * bsa * (1-(0.168*ifelse(sex == "male", 0, 1))))/scr
+}
+
+#' @rdname calc_egfr
+egfr_jelliffe <- function(age, sex, bsa, scr) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  ((98 - 0.8*(age - 20)) * (1 - 0.01 * ifelse(sex == "male", 0, 1)) * bsa/1.73) / scr
+}
+
+#' @rdname calc_egfr
+egfr_jelliffe_unstable <- function(weight, times, scr, age, sex) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  vol <- 4 * weight
+
+  # for times, if null or negative or mismatch in times/scr length, assume one day difference
+  # otherwise, ensure times and scrs are sequential.
+  if (is.null(times) | length(scr) != length(times)) {
+    dt <- rep(1, length(scr))
+  } else {
+    scr <- scr[order(times)]
+    times <- sort(times)
+    dt <- c(1, diff(times))
+  }
+
+  # for first creatinine, use that value. for subsequent creatinines, use average of current and previous values.
+  if (length(scr) == 1) {
+    scr_diff <- 0
+    scr_av <- scr
+  } else {
+    scr_diff <- c(0, diff(scr)) * -1
+    scr_av <- scr + scr_diff/2
+  }
+
+  # calculate creatinine production
+  cr_prod <- (29.305-(0.203 * age)) * weight * (1.037-(0.0338 * scr_av)) * ifelse(sex == "male", 0.85, 0.765)
+  # calculate crcl
+  ((vol * scr_diff/dt + cr_prod) * 100) / (1440 * scr_av)
+}
+
+#' @rdname calc_egfr
+egfr_mdrd <- function(sex, race, scr, age, use_race) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  f_sex <- ifelse(sex == 'female', 0.762, 1)
+  f_race <- ifelse(race == 'black' && use_race == TRUE, 1.21, 1)
+  186 * scr^(-1.154) * f_sex * f_race * age^(-0.203)
+}
+
+#' @rdname calc_egfr
+egfr_ckd_epi <- function(sex, race, scr, age, use_race) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  f_sex <- ifelse(sex == 'female', 1.018, 1)
+  f_race <- ifelse(race == 'black' && use_race == TRUE, 1.159, 1)
+  141 * (scr ^ ifelse(scr < 1, -0.329, -1.209)) * 0.993^age * f_sex * f_race
+}
+
+#' @rdname calc_egfr
+egfr_cockcroft_gault_sci <- function(sex, age, scr, weight) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  f_sex <- ifelse(sex == 'female', 0.85, 1)
+  2.3 * (f_sex * (140-age) / scr * (weight/72)) ^0.7
+}
+
+#' @rdname calc_egfr
+egfr_cockcroft_gault <- function(sex, age, scr, weight) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  f_sex <- ifelse(sex == 'female', 0.85, 1)
+  f_sex * (140-age) / scr * (weight/72)
+}
+
+#' @rdname calc_egfr
+egfr_malmo_lund <- function(sex, age, scr) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  scr_cutoff <- ifelse(sex == 'female', 1.696833, 2.0362)
+  intercept <- ifelse(sex == 'female', 2.5, 2.56)
+  slope <- ifelse(
+    scr >= scr_cutoff,
+    -0.926,
+    ifelse(sex == 'female', 1.06964, 0.855712)
+  )
+  cr_term <- ifelse(scr < scr_cutoff, scr_cutoff - scr, log(scr/scr_cutoff))
+  x <- intercept + slope * cr_term
+  exp(x - 0.0158*age + 0.438*log(age))
+}
+
+#' @rdname calc_egfr
+egfr_bedside_schwartz <- function(age, height, scr, verbose) {
+  if(age < 1 && verbose) warning("This equation is not meant for patients < 1 years of age.")
+  k <- 0.413
+  (k * height) / scr
+}
+
+#' @rdname calc_egfr
+egfr_schwartz <- function(age, preterm, sex, height, scr) {
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  k <- ifelse(
+    preterm & age < 1,
+    0.33,
+    ifelse(
+      age < 1,
+      0.45,
+      ifelse(
+        age > 13 & sex == 'male',
+        0.7,
+        0.55
+      )
+    )
+  )
+  (k * height) / scr
 }

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -399,6 +399,8 @@ egfr_jelliffe_unstable <- function(weight, times, scr, age, sex) {
 }
 
 #' @rdname calc_egfr
+#' @param use_race whether to include race as a factor in the calculation (TRUE
+#'   or FALSE); see note
 egfr_mdrd <- function(sex, race, scr, age, use_race) {
   if (!sex %in% c("male", "female")) {
     warning("This method requires sex to be one of 'male' or 'female'.")

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -274,7 +274,7 @@ calc_egfr <- function (
       height = height,
       scr = scr
     ),
-    FALSE
+    NULL
   )
 
   # Format Output

--- a/R/calc_ffm.R
+++ b/R/calc_ffm.R
@@ -74,7 +74,7 @@ calc_ffm <- function (
       age = age
     ),
     "hume" = ffm_hume(weight = weight, height = height, sex = sex),
-    "james" = ffm_james(weight = weight, heigh = height, sex = sex),
+    "james" = ffm_james(weight = weight, height = height, sex = sex),
     "garrow_webster" = ffm_garrow_webster(
       weight = weight,
       height = height,

--- a/R/calc_ffm.R
+++ b/R/calc_ffm.R
@@ -151,11 +151,8 @@ ffm_bucaloiu <- function(weight, sex, height, age) {
   if(is.null(weight) || is.null(height) || is.null(sex) || is.null(age)) {
     stop("Equation needs weight, height, sex, and age of patient!")
   }
-  if(!sex == "female") {
-    warning("This equation is only meant for (obese) females.")
-  }
   bmi <- calc_bmi(weight = weight, height = height)
-  if(any(bmi < 25)) {
+  if(any(bmi < 25) || !sex == "female") {
     warning("This equation is only meant for obese females.")
   }
   ffm <- -11.41 + 0.354 * weight + 11.06 * height/100

--- a/R/calc_ffm.R
+++ b/R/calc_ffm.R
@@ -38,9 +38,6 @@ calc_ffm <- function (
   method = c("janmahasatian", "green", "al-sallami", "storset", "bucaloiu", "hume", "james", "garrow_webster"),
   digits = 1) {
   method <- match.arg(method)
-  if(is.null(sex) || !(sex %in% c("male", "female"))) {
-    stop("Sex needs to be either male or female!")
-  }
   sex <- tolower(sex)
 
   ffm <- switch(
@@ -96,22 +93,30 @@ calc_ffm <- function (
 ffm_janmahasatian_green <- function(weight, sex, height = NULL, bmi = NULL) {
   if(is.null(weight) || (is.null(bmi) & is.null(height)) || is.null(sex)) {
     stop("Equation needs weight, BMI or height, and sex of patient!")
-  } else {
-    if(is.null(bmi)) {
-      bmi <- calc_bmi(height = height, weight = weight)
-    }
-    if(sex == "male") {
-      ffm <- (9.27e03 * weight) / ((6.68e03) + 216 * bmi)
-    } else {
-      ffm <- (9.27e03 * weight) / ((8.78e03) + 244 * bmi)
-    }
   }
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  if(is.null(bmi)) {
+    bmi <- calc_bmi(height = height, weight = weight)
+  }
+  if(sex == "male") {
+    ffm <- (9.27e03 * weight) / ((6.68e03) + 216 * bmi)
+  } else {
+    ffm <- (9.27e03 * weight) / ((8.78e03) + 244 * bmi)
+  }
+
 }
 
 #' @rdname calc_ffm
 ffm_al_sallami <- function(weight, sex, age, height = NULL, bmi = NULL) {
   if(is.null(weight) || (is.null(bmi) & is.null(height)) || is.null(sex) || is.null(age)) {
-    stop("Equation needs weight, BMI or height, and sex of patient!")
+    stop("Equation needs weight, BMI or height, sex, and age of patient!")
+  }
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
   }
   if(is.null(bmi)) {
     bmi <- calc_bmi(weight = weight, height = height)
@@ -127,12 +132,15 @@ ffm_al_sallami <- function(weight, sex, age, height = NULL, bmi = NULL) {
 ffm_storset <- function(weight, sex, height, age) {
   if(is.null(weight) || is.null(height) || is.null(sex) || is.null(age)) {
     stop("Equation needs weight, height, sex, and age of patient!")
+  }
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  if(sex == "male") {
+    ffm <- (11.4 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1-age*0.0007)
   } else {
-    if(sex == "male") {
-      ffm <- (11.4 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1-age*0.0007)
-    } else {
-      ffm <- (10.2 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1-age*0.0007)
-    }
+    ffm <- (10.2 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1-age*0.0007)
   }
 }
 
@@ -140,29 +148,30 @@ ffm_storset <- function(weight, sex, height, age) {
 ffm_bucaloiu <- function(weight, sex, height, age) {
   if(is.null(weight) || is.null(height) || is.null(sex) || is.null(age)) {
     stop("Equation needs weight, height, sex, and age of patient!")
-  } else {
-    if(sex == "male") {
-      stop("This equation is only meant for (obese) females.")
-    } else {
-      bmi <- calc_bmi(weight = weight, height = height)
-      if(any(bmi < 25)) {
-        warning("This equation is only meant for obese females.")
-      }
-      ffm <- -11.41 + 0.354 * weight + 11.06 * height/100
-    }
   }
+  if(!sex == "female") {
+    warning("This equation is only meant for (obese) females.")
+  }
+  bmi <- calc_bmi(weight = weight, height = height)
+  if(any(bmi < 25)) {
+    warning("This equation is only meant for obese females.")
+  }
+  ffm <- -11.41 + 0.354 * weight + 11.06 * height/100
 }
 
 #' @rdname calc_ffm
 ffm_hume <- function(weight, sex, height) {
   if(is.null(weight) || is.null(height) || is.null(sex)) {
     stop("Equation needs weight, height, sex of patient!")
+  }
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  if(sex == "male") {
+    ffm <- 0.3281 * weight + 0.33929 * height - 29.5336
   } else {
-    if(sex == "male") {
-      ffm <- 0.3281 * weight + 0.33929 * height - 29.5336
-    } else {
-      ffm <- 0.29569 * weight + 0.41813 * height - 43.2933
-    }
+    ffm <- 0.29569 * weight + 0.41813 * height - 43.2933
   }
 }
 
@@ -170,24 +179,30 @@ ffm_hume <- function(weight, sex, height) {
 ffm_james <- function(weight, sex, height) {
   if(is.null(weight) || is.null(height) || is.null(sex)) {
     stop("Equation needs weight, height, sex of patient!")
+  }
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  if(sex == "male") {
+    ffm <- 1.1 * weight - 128*(weight/height)^2
   } else {
-    if(sex == "male") {
-      ffm <- 1.1 * weight - 128*(weight/height)^2
-    } else {
-      ffm <- 1.07 * weight - 148*(weight/height)^2
-    }
+    ffm <- 1.07 * weight - 148*(weight/height)^2
   }
 }
 
 #' @rdname calc_ffm
 ffm_garrow_webster <- function(weight, sex, height) {
   if(is.null(weight) || is.null(height) || is.null(sex)) {
-    stop("Equation needs weight, height of patient!")
+    stop("Equation needs weight, height, and sex of patient!")
+  }
+  if (!sex %in% c("male", "female")) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  if(sex == "male") {
+    ffm <- 0.285 * weight + 12.1*(height/100)^2
   } else {
-    if(sex == "male") {
-      ffm <- 0.285 * weight + 12.1*(height/100)^2
-    } else {
-      ffm <- 0.287 * weight + 9.74*(height/100)^2
-    }
+    ffm <- 0.287 * weight + 9.74*(height/100)^2
   }
 }

--- a/R/calc_ffm.R
+++ b/R/calc_ffm.R
@@ -19,7 +19,7 @@
 #' @param height height in cm, only required for `holford` method, can be used instead of `bmi` for `green` method
 #' @param sex sex, either `male` of `female`
 #' @param age age, only used for Storset equation
-#' @param method estimation method, either `green` (default), `holford`, or `storset`
+#' @param method estimation method, one of `janmahasatian` (default), `green`, `al-sallami`, `storset`, `bucaloiu`, `hume`, `james`, or `garrow_webster`.
 #' @param digits round to number of digits
 #' @return Returns a list of the following elements:
 #' \item{value}{Fat-free Mass (FFM) in units of kg}
@@ -35,12 +35,9 @@ calc_ffm <- function (
   sex = NULL,
   height = NULL,
   age = NULL,
-  method = "janmahasatian",
+  method = c("janmahasatian", "green", "al-sallami", "storset", "bucaloiu", "hume", "james", "garrow_webster"),
   digits = 1) {
-  methods <- c("janmahasatian", "green", "al-sallami", "storset", "bucaloiu", "hume", "james", "garrow_webster")
-  if(! method %in% methods) {
-    stop(paste0("Unknown estimation method, please choose from: ", paste(methods, collapse=" ")))
-  }
+  method <- match.arg(method)
   if(is.null(sex) || !(sex %in% c("male", "female"))) {
     stop("Sex needs to be either male or female!")
   }

--- a/R/calc_ffm.R
+++ b/R/calc_ffm.R
@@ -106,7 +106,7 @@ ffm_janmahasatian_green <- function(weight, sex, height = NULL, bmi = NULL) {
   } else {
     ffm <- (9.27e03 * weight) / ((8.78e03) + 244 * bmi)
   }
-
+  ffm
 }
 
 #' @rdname calc_ffm
@@ -126,6 +126,7 @@ ffm_al_sallami <- function(weight, sex, age, height = NULL, bmi = NULL) {
   } else {
     ffm <- (0.88 + ((1-0.88)/(1+(age/13.4)^-12.7))) * ((9270 * weight)/(6680 + (216 * bmi)))
   }
+  ffm
 }
 
 #' @rdname calc_ffm
@@ -142,6 +143,7 @@ ffm_storset <- function(weight, sex, height, age) {
   } else {
     ffm <- (10.2 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1-age*0.0007)
   }
+  ffm
 }
 
 #' @rdname calc_ffm
@@ -157,6 +159,7 @@ ffm_bucaloiu <- function(weight, sex, height, age) {
     warning("This equation is only meant for obese females.")
   }
   ffm <- -11.41 + 0.354 * weight + 11.06 * height/100
+  ffm
 }
 
 #' @rdname calc_ffm
@@ -173,6 +176,7 @@ ffm_hume <- function(weight, sex, height) {
   } else {
     ffm <- 0.29569 * weight + 0.41813 * height - 43.2933
   }
+  ffm
 }
 
 #' @rdname calc_ffm
@@ -189,6 +193,7 @@ ffm_james <- function(weight, sex, height) {
   } else {
     ffm <- 1.07 * weight - 148*(weight/height)^2
   }
+  ffm
 }
 
 #' @rdname calc_ffm
@@ -205,4 +210,5 @@ ffm_garrow_webster <- function(weight, sex, height) {
   } else {
     ffm <- 0.287 * weight + 9.74*(height/100)^2
   }
+  ffm
 }

--- a/R/calc_ibw.R
+++ b/R/calc_ibw.R
@@ -87,19 +87,23 @@ calc_ibw <- function (
 #' @inheritParams calc_ibw
 ibw_standard <- function(age, height = NULL, sex = NULL) {
   if (is.null(age) || age >= 18 || age < 1) {
-    stop("Age must be >=1 and <18")
+    warning("Age should be >=1 and <18 for the `standard` method.")
   }
   if (is.null(height) || is.na(height)) {
-    message("Height is required to calculate IBW")
-    return(NA)
+    stop("Height is required to calculate IBW")
   }
   height_in <- cm2inch(height)
   if (height_in < 5 * 12) {
     return((height^2 * 1.65) / 1000)
   }
-  if (is.null(sex) || is.na(sex) || !sex %in% c("male", "female")) {
-    message("The `standard` method for calculating IBW requires sex to be 'male' or 'female' for children 5 feet tall or taller.")
-    return(NA)
+  if (is.null(sex) || is.na(sex)) {
+    # Sex is only required if height >= 5ft, so this must come after the lines
+    # above
+    stop("Sex is required to calculate IBW when height is >= 5 feet")
+  }
+  if (!sex %in% c("male", "female")) {
+    warning("The `standard` method for calculating IBW requires sex to be 'male' or 'female' for children 5 feet tall or taller.")
+    return(NULL)
   }
   base_value <- switch(
     sex,
@@ -115,15 +119,14 @@ ibw_standard <- function(age, height = NULL, sex = NULL) {
 #' @inheritParams calc_ibw
 ibw_devine <- function(age, height = NULL, sex = NULL) {
   if (age < 18) {
-    stop("Age must be >= 18 for the Devine equation")
+    warning("Age should be >18 for the `devine` method.")
   }
-  if (is.null(height) || is.na(height)) {
-    message("Height is required to calculate IBW")
-    return(NA)
+  if (is.null(height) || is.na(height) || is.null(sex) || is.na(sex)) {
+    stop("Height and sex are required to calculate IBW")
   }
-  if (is.null(sex) || is.na(sex) || !sex %in% c("male", "female")) {
-    message("The `devine` method for calculating IBW requires sex to be 'male' or 'female'.")
-    return(NA)
+  if (!sex %in% c("male", "female")) {
+    warning("The `devine` method for calculating IBW requires sex to be 'male' or 'female'.")
+    return(NULL)
   }
   base_value <- switch(
     sex,

--- a/man/calc_egfr.Rd
+++ b/man/calc_egfr.Rd
@@ -101,6 +101,9 @@ See Note section below for important considerations when using race as a predict
 \item{fail}{invoke `stop()` if not all covariates available?}
 
 \item{...}{arguments passed on to `calc_abw` or `calc_dosing_weight`}
+
+\item{use_race}{whether to include race as a factor in the calculation (TRUE
+or FALSE); see note}
 }
 \description{
 Calculate the estimated glomerular filtration rate (an indicator of renal function) based on measured serum creatinine using one of the following approaches:

--- a/man/calc_egfr.Rd
+++ b/man/calc_egfr.Rd
@@ -2,6 +2,16 @@
 % Please edit documentation in R/calc_egfr.R
 \name{calc_egfr}
 \alias{calc_egfr}
+\alias{egfr_wright}
+\alias{egfr_jelliffe}
+\alias{egfr_jelliffe_unstable}
+\alias{egfr_mdrd}
+\alias{egfr_ckd_epi}
+\alias{egfr_cockcroft_gault_sci}
+\alias{egfr_cockcroft_gault}
+\alias{egfr_malmo_lund}
+\alias{egfr_bedside_schwartz}
+\alias{egfr_schwartz}
 \title{Calculate eGFR}
 \usage{
 calc_egfr(
@@ -26,6 +36,26 @@ calc_egfr(
   fail = TRUE,
   ...
 )
+
+egfr_wright(age, bsa, sex, scr)
+
+egfr_jelliffe(age, sex, bsa, scr)
+
+egfr_jelliffe_unstable(weight, times, scr, age, sex)
+
+egfr_mdrd(sex, race, scr, age, use_race)
+
+egfr_ckd_epi(sex, race, scr, age, use_race)
+
+egfr_cockcroft_gault_sci(sex, age, scr, weight)
+
+egfr_cockcroft_gault(sex, age, scr, weight)
+
+egfr_malmo_lund(sex, age, scr)
+
+egfr_bedside_schwartz(age, height, scr, verbose)
+
+egfr_schwartz(age, preterm, sex, height, scr)
 }
 \arguments{
 \item{method}{eGFR estimation method, choose from `cockcroft_gault`, `cockcroft_gault_ideal`, 
@@ -109,7 +139,7 @@ calc_egfr(sex = "male", age = 50, scr = c(1.1, 0.8),
 calc_egfr(sex = "male", age = 50, scr = c(1.1, 0.8),
   weight = 70, height = 170, method = "jelliffe_unstable")
 calc_egfr(sex = "male", age = 50, scr = 1.1,
-  weight = 70, bsa = 1.6, method = "malmo_lund_rev", relative = FALSE)
+  weight = 70, bsa = 1.6, method = "malmo_lund_revised", relative = FALSE)
 }
 \references{
 \itemize{

--- a/man/calc_ffm.Rd
+++ b/man/calc_ffm.Rd
@@ -10,7 +10,8 @@ calc_ffm(
   sex = NULL,
   height = NULL,
   age = NULL,
-  method = "janmahasatian",
+  method = c("janmahasatian", "green", "al-sallami", "storset", "bucaloiu", "hume",
+    "james", "garrow_webster"),
   digits = 1
 )
 }
@@ -25,7 +26,7 @@ calc_ffm(
 
 \item{age}{age, only used for Storset equation}
 
-\item{method}{estimation method, either `green` (default), `holford`, or `storset`}
+\item{method}{estimation method, one of `janmahasatian` (default), `green`, `al-sallami`, `storset`, `bucaloiu`, `hume`, `james`, or `garrow_webster`.}
 
 \item{digits}{round to number of digits}
 }

--- a/man/calc_ffm.Rd
+++ b/man/calc_ffm.Rd
@@ -2,6 +2,13 @@
 % Please edit documentation in R/calc_ffm.R
 \name{calc_ffm}
 \alias{calc_ffm}
+\alias{ffm_janmahasatian_green}
+\alias{ffm_al_sallami}
+\alias{ffm_storset}
+\alias{ffm_bucaloiu}
+\alias{ffm_hume}
+\alias{ffm_james}
+\alias{ffm_garrow_webster}
 \title{Calculate fat-free mass}
 \usage{
 calc_ffm(
@@ -14,6 +21,20 @@ calc_ffm(
     "james", "garrow_webster"),
   digits = 1
 )
+
+ffm_janmahasatian_green(weight, sex, height = NULL, bmi = NULL)
+
+ffm_al_sallami(weight, sex, age, height = NULL, bmi = NULL)
+
+ffm_storset(weight, sex, height, age)
+
+ffm_bucaloiu(weight, sex, height, age)
+
+ffm_hume(weight, sex, height)
+
+ffm_james(weight, sex, height)
+
+ffm_garrow_webster(weight, sex, height)
 }
 \arguments{
 \item{weight}{total body weight in kg}

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -480,3 +480,17 @@ test_that("eGFR for mdrd_ignore_race", {
     )$value
   )
 })
+
+test_that("calc_egfr warns and returns NULL if sex isn't supported", {
+  expect_warning(
+    res <- calc_egfr(
+      age = 40,
+      sex = "unknown",
+      weight = 80,
+      scr = 1,
+      method = "cockcroft_gault",
+      verbose = FALSE
+    )
+  )
+  expect_null(res$value)
+})

--- a/tests/testthat/test_calc_ffm.R
+++ b/tests/testthat/test_calc_ffm.R
@@ -31,3 +31,92 @@ test_that("FFM calculation works", {
     36
   )
 })
+
+test_that("ffm functions error if missing info", {
+  expect_error(
+    ffm_janmahasatian_green(weight = 80, sex = "male")
+  )
+  expect_error(
+    ffm_al_sallami(weight = 80, sex = "male", height = 180, age = NULL)
+  )
+  expect_error(ffm_storset(weight = NULL, sex = "female", height = 180))
+  expect_error(ffm_bucaloiu(weight = NULL, height = NULL, sex = NULL))
+  expect_error(ffm_hume(weight = 80, sex = NULL, height = 150))
+  expect_error(ffm_james(weight = NULL, sex = NULL, height = NULL))
+  expect_error(ffm_garrow_webster(weight = 90, sex = "female", height = NULL))
+})
+
+test_that("ffm functions warn and return NULL if sex not supported", {
+  expect_warning(
+    expect_null(
+      ffm_janmahasatian_green(weight = 80, sex = "unknown", height = 150)
+    )
+  )
+  expect_warning(
+    expect_null(
+      ffm_al_sallami(weight = 80, sex = "unknown", height = 180, age = 20)
+    )
+  )
+  expect_warning(
+    expect_null(
+      ffm_storset(weight = 80, sex = "unknown", height = 180, age = 20)
+    )
+  )
+  expect_warning(
+    expect_null(
+      ffm_hume(weight = 80, sex = "unknown", height = 150)
+    )
+  )
+  expect_warning(
+    expect_null(
+      ffm_james(weight = 80, sex = "unknown", height = 150)
+    )
+  )
+  expect_warning(
+    expect_null(
+      ffm_garrow_webster(weight = 90, sex = "unknown", height = 150)
+    )
+  )
+})
+
+test_that("ffm_bucaloiu warns if used for other than obese females", {
+  expect_warning(
+    res1 <- ffm_bucaloiu(weight = 50, sex = "female", height = 150, age = 20)
+  )
+  expect_warning(
+    res2 <- ffm_bucaloiu(weight = 100, sex = "unknown", height = 150, age = 20)
+  )
+  expect_equal(res1, 22.88)
+  expect_equal(res2, 40.58)
+})
+
+test_that("ffm equations give expected values", {
+  expect_equal(
+    ffm_janmahasatian_green(weight = 80, sex = "male", height = 150),
+    51.643454
+  )
+  expect_equal(
+    ffm_al_sallami(weight = 80, sex = "male", height = 150, age = 20),
+    51.605376
+  )
+  expect_equal(
+    ffm_storset(weight = 80, sex = "male", height = 180, age = 20),
+    57.756004
+  )
+  expect_equal(
+    ffm_bucaloiu(weight = 80, sex = "female", height = 150, age = 20),
+    33.5
+  )
+  expect_equal(
+    ffm_hume(weight = 80, sex = "female", height = 150),
+    43.0814
+  )
+  expect_equal(
+    ffm_james(weight = 80, sex = "female", height = 150),
+    43.502222
+  )
+  expect_equal(
+    ffm_garrow_webster(weight = 80, sex = "female", height = 150),
+    44.875
+  )
+})

--- a/tests/testthat/test_calc_ibw.R
+++ b/tests/testthat/test_calc_ibw.R
@@ -30,23 +30,23 @@ test_that("calc_ibw() uses weight when age < 1", {
   )
 })
 
-test_that("ibw_standard only supports children and requires age", {
-  expect_error(ibw_standard(age = 25))
-  expect_error(ibw_standard(age = NULL))
+test_that("ibw_standard warns if used for adults/missing age", {
+  expect_warning(ibw_standard(age = 25, height = 100, sex = "male"))
+  expect_warning(ibw_standard(age = NULL, height = 100, sex = "male"))
 })
 
-test_that("ibw_standard returns NA and message if missing data", {
-  res1 <- expect_message(ibw_standard(age = 10, height = NA))
-  res2 <- expect_message(ibw_standard(age = 10, height = NULL))
-  expect_true(is.na(res1))
-  expect_true(is.na(res2))
+test_that("ibw_standard errors if missing data", {
+  expect_error(ibw_standard(age = 10, height = NA, sex = "female"))
+  expect_error(ibw_standard(age = 10, height = NULL, sex = "female"))
+  expect_error(ibw_standard(age = 17, height = 165, sex = NULL))
+  expect_error(ibw_standard(age = 17, height = 165, sex = NA))
+})
 
-  res3 <- expect_message(ibw_standard(age = 17, height = 165))
-  res4 <- expect_message(
-    ibw_standard(age = 17, height = 165, sex = "unknown")
+test_that("ibw_standard returns NULL if sex isn't supported", {
+  expect_warning(
+    res <- ibw_standard(age = 17, height = 165, sex = "unknown")
   )
-  expect_true(is.na(res3))
-  expect_true(is.na(res4))
+  expect_null(res)
 })
 
 test_that("ibw_standard doesn't require sex if height < 5ft", {
@@ -65,22 +65,22 @@ test_that("ibw_standard calculates correct IBW", {
 })
 
 test_that("ibw_devine only supports adults and requires age", {
-  expect_error(ibw_devine(age = 15))
   expect_error(ibw_devine(age = NULL))
+  expect_warning(ibw_devine(age = 15, sex = "female", height = 150))
 })
 
 test_that("ibw_devine returns NA and message if missing data", {
-  res1 <- expect_message(ibw_devine(age = 20, height = NA))
-  res2 <- expect_message(ibw_devine(age = 20, height = NULL))
-  expect_true(is.na(res1))
-  expect_true(is.na(res2))
+  expect_error(ibw_devine(age = 20, height = NA, sex = "female"))
+  expect_error(ibw_devine(age = 20, height = NULL, sex = "female"))
+  expect_error(ibw_devine(age = 30, height = 165, sex = NULL))
+  expect_error(ibw_devine(age = 30, height = 165, sex = NA))
+})
 
-  res3 <- expect_message(ibw_devine(age = 30, height = 165))
-  res4 <- expect_message(
-    ibw_devine(age = 30, height = 165, sex = "unknown")
+test_that("ibw_devine returns NULL if sex isn't supported", {
+  expect_warning(
+    res <- ibw_devine(age = 30, height = 165, sex = "unknown")
   )
-  expect_true(is.na(res3))
-  expect_true(is.na(res4))
+  expect_null(res)
 })
 
 test_that("ibw_devine calculates correct IBW", {


### PR DESCRIPTION
* If required information is missing, we throw an error
* If data is provided but not recognized/supported by the method, we throw a warning and return `NULL`.
* If data is provided that doesn't match the intended use of the method but it's possible to still calculate the result (e.g. the age is outside the range the method is intended for) we throw a warning but still calculate the value

For `calc_egfr()` and `calc_ffm()`, the functions were relatively long with conditional branches for each method. Rather than add more lines I opted to split the code into separate functions for each method, which seemed a bit cleaner, but does make the diff rather large. I added a number of tests for the `calc_ffm()` methods; `calc_egfr()` was already relatively well covered so I just added a test for the new behavior there.