### PR TITLE
RXR-503: Fix KDIGO staging criteria

### DIFF
--- a/R/calc_aki_stage.R
+++ b/R/calc_aki_stage.R
@@ -162,9 +162,9 @@ calc_aki_stage <- function (
     dat$stage[dat$baseline_scr_diff >= 0.5 | dat$scr >= 4.0] <- 3
     
   } else if (method == "kdigo") {
-    dat$stage[dat$baseline_scr_reldiff >= 1.5 | dat$baseline_scr_diff >= 0.3] <- 1
-    dat$stage[dat$baseline_scr_reldiff >= 2.0 ] <- 2
-    dat$stage[dat$baseline_scr_reldiff >= 3.0 | dat$scr >= 4.0 | (dat$egfr < 35 & age < 18)] <- 3
+    dat$stage[dat$scr / baseline_scr >= 1.5 | dat$baseline_scr_diff >= 0.3] <- 1
+    dat$stage[dat$scr / baseline_scr >= 2 ] <- 2
+    dat$stage[dat$scr / baseline_scr >= 3 | dat$scr >= 4 | (dat$egfr < 35 & age < 18)] <- 3
   }
 
   ## get max class, convert to character class:

--- a/tests/testthat/test_calc_aki_stage.R
+++ b/tests/testthat/test_calc_aki_stage.R
@@ -36,6 +36,15 @@ test_that("AKI stage is calculated correctly", {
     force_numeric = TRUE,
     verbose = FALSE
   )
+  test3 <- calc_aki_stage(
+    scr = 1.9,
+    t = 72,
+    baseline_scr = 0.9,
+    egfr = 40,
+    age = 40,
+    return_obj = FALSE,
+    verbose = FALSE
+  )
   expect_equal(test0$stage, "stage 3")
   expect_equal(test1$stage, "stage 1")
   expect_equal(test2$stage, "stage 3")
@@ -43,6 +52,7 @@ test_that("AKI stage is calculated correctly", {
   expect_equal(test2a$stage, "stage 1")
   expect_equal(test2a$time_max_stage, 48)
   expect_equal(test2b, 1)
+  expect_equal(test3, "stage 2")
 })
 
 


### PR DESCRIPTION
This PR corrects the KDIGO criteria for AKI staging. These were previously fixed, but while resolving a merge conflict before the PR was merged they regressed. Interestingly, none of the existing tests were affected by the change. I added a test that would fail before this update but now passes.