### PR TITLE
RXR-624

### DIFF
--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -462,9 +462,11 @@ egfr_ckd_epi <- function(sex, race, scr, age, use_race) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
+  a1 <- ifelse(sex == 'female', -0.329, -0.411)
+  K <- ifelse(sex == 'female', 0.7, 0.9)
   f_sex <- ifelse(sex == 'female', 1.018, 1)
   f_race <- ifelse(race == 'black' && use_race == TRUE, 1.159, 1)
-  141 * (scr ^ ifelse(scr < 1, -0.329, -1.209)) * 0.993^age * f_sex * f_race
+  141 * ((scr/K) ^ ifelse(scr < K, a1, -1.209)) * 0.993^age * f_sex * f_race
 }
 
 #' @rdname calc_egfr
@@ -474,9 +476,9 @@ egfr_ckd_epi_as_2021 <- function(sex, scr, age) {
     return(NULL)
   }
   a1 <- ifelse(sex == 'female', -0.241, -0.302)
-  cr_spline <- ifelse(sex == 'female', 0.7, 0.9)
+  K <- ifelse(sex == 'female', 0.7, 0.9)
   f_sex <- ifelse(sex == 'female', 1.012, 1)
-  142 * (scr ^ ifelse(scr < cr_spline, a1, -1.200)) * 0.9938^age * f_sex
+  142 * ((scr/K) ^ ifelse(scr < K, a1, -1.200)) * 0.9938^age * f_sex
 }
 
 #' @rdname calc_egfr

--- a/R/egfr_cov_reqs.R
+++ b/R/egfr_cov_reqs.R
@@ -20,8 +20,9 @@ egfr_cov_reqs <- function(method, relative = NULL){
     "cockcroft_gault_adaptive", "cockcroft_gault_sci",
     "malmo_lund_revised", "malmo_lund_rev", "lund_malmo_revised", "lund_malmo_rev",
     "mdrd", "mdrd_ignore_race", "mdrd_original", "mdrd_original_ignore_race",
-    "ckd_epi", "ckd_epi_ignore_race", "schwartz", "schwartz_revised", 
-    "bedside_schwartz", "jelliffe", "jelliffe_unstable", "wright"
+    "ckd_epi", "ckd_epi_ignore_race", "ckd_epi_as_2021", 
+    "schwartz", "schwartz_revised", "bedside_schwartz", 
+    "jelliffe", "jelliffe_unstable", "wright"
   )
   if(!(method %in% available_methods)) {
     stop(paste0("Sorry, eGFR calculation method not recognized! Please choose from: ", 
@@ -32,7 +33,7 @@ egfr_cov_reqs <- function(method, relative = NULL){
   if (method %in% c("cockcroft_gault", "jelliffe_unstable", "cockcroft_gault_sci")) {
     covs <- list(c("creat", "age", "weight", "sex"))
     
-  } else if (method %in% c("malmo_lund_revised", "malmo_lund_rev", "lund_malmo_revised", "lund_malmo_rev", "mdrd_ignore_race", "mdrd_original_ignore_race", "ckd_epi_ignore_race")) {
+  } else if (method %in% c("malmo_lund_revised", "malmo_lund_rev", "lund_malmo_revised", "lund_malmo_rev", "mdrd_ignore_race", "mdrd_original_ignore_race", "ckd_epi_ignore_race", "ckd_epi_as_2021")) {
     covs <- list(c("creat", "sex", "age"))
     
   } else if (method %in% c("schwartz_revised", "bedside_schwartz")) {

--- a/man/calc_egfr.Rd
+++ b/man/calc_egfr.Rd
@@ -7,6 +7,7 @@
 \alias{egfr_jelliffe_unstable}
 \alias{egfr_mdrd}
 \alias{egfr_ckd_epi}
+\alias{egfr_ckd_epi_as_2021}
 \alias{egfr_cockcroft_gault_sci}
 \alias{egfr_cockcroft_gault}
 \alias{egfr_malmo_lund}
@@ -47,6 +48,8 @@ egfr_mdrd(sex, race, scr, age, use_race, original_expression)
 
 egfr_ckd_epi(sex, race, scr, age, use_race)
 
+egfr_ckd_epi_as_2021(sex, scr, age)
+
 egfr_cockcroft_gault_sci(sex, age, scr, weight)
 
 egfr_cockcroft_gault(sex, age, scr, weight)
@@ -60,7 +63,8 @@ egfr_schwartz(age, preterm, sex, height, scr)
 \arguments{
 \item{method}{eGFR estimation method, choose from `cockcroft_gault`, `cockcroft_gault_ideal`, 
 `cockcroft_gault_adjusted`, `cockcroft_gault_adaptive`, `mdrd`, 
-`mdrd_ignore_race`, `mdrd_original`, `mdrd_original_ignore_race`, `ckd_epi`, `ckd_epi_ignore_race`, 
+`mdrd_ignore_race`, `mdrd_original`, `mdrd_original_ignore_race`, 
+`ckd_epi`, `ckd_epi_ignore_race`, `ckd_epi_as_2021`,
 `malmo_lund_revised`, `schwartz`, `jelliffe`, `jellife_unstable`, `wright`.}
 
 \item{sex}{sex}
@@ -72,7 +76,7 @@ egfr_schwartz(age, preterm, sex, height, scr)
 \item{scr_unit, }{`mg/dL` or `micromol/L` (==`umol/L`)}
 
 \item{race}{`black` or `other`, Required for CKD-EPI and MDRD methods for estimating GFR. 
-To use these methods without race, use `method = "ckd_epi_ignore_race"`,  
+To use these methods without race, use `method = "ckd_epi_ignore_race"`,  `method = "ckd_epi_as_2021"`,
 `method = "mdrd_ignore_race"` or `method = "mdrd_original_ignore_race"`.
 See Note section below for important considerations when using race as a predictive factor in eGFR.}
 
@@ -123,7 +127,7 @@ approaches:
     with or without consideration of race, using either the original equation 
     (published 2001) or the equation updated to reflect serum creatinine 
     assay standardization (2006))
-  \item CKD-EPI (with or without consideration of race)
+  \item CKD-EPI (with or without consideration of race, or 2021 re-fit without race)
   \item Schwartz
   \item Schwartz revised / bedside
   \item Jelliffe
@@ -143,6 +147,10 @@ The MDRD and CKD-EPI equations use race as a factor in estimation of GFR. Racism
   On the other hand, including race in GFR estimation may also prevent Black patients 
   from obtaining procedures like kidney transplants
   ({\href{https://pubmed.ncbi.nlm.nih.gov/33443583/}{Zelnick, et al. JAMA Netw Open. (2021)}}).
+  In 2021, the NKF/ASN Task Force on Reassessing the Inclusion of Race in Diagnosing Kidney Diseases
+  published revised versions of the CKD-EPI equations refit on the original data but with race excluded, 
+  which may produce less biased estimates 
+  (\href{https://www.nejm.org/doi/full/10.1056/NEJMoa2102953}{Inker, et al., NEJM (2021)}).
 }
 \examples{
 calc_egfr(sex = "male", age = 50, scr = 1.1, weight = 70)
@@ -163,6 +171,7 @@ calc_egfr(sex = "male", age = 50, scr = 1.1,
   \item MDRD: \href{https://pubmed.ncbi.nlm.nih.gov/11706306/}{Manjunath et al., Curr. Opin. Nephrol. Hypertens. (2001)} 
     and \href{https://academic.oup.com/clinchem/article/53/4/766/5627682}{Levey et al., Clinical Chemistry (2007)}. (See Note.)
   \item CKD-EPI: \href{https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2763564/}{Levey et al., Annals of Internal Medicine (2009)}. (See Note.)
+  \item CKD-EPI (2021): \href{https://www.nejm.org/doi/full/10.1056/NEJMoa2102953}{Inker, et al., NEJM (2021)}.
   \item Schwartz: \href{https://www.ncbi.nlm.nih.gov/pubmed/951142}{Schwartz et al., Pediatrics (1976)}
   \item Schwartz revised / bedside: \href{https://www.ncbi.nlm.nih.gov/pubmed/19158356}{Schwartz et al., Journal of the American Society of Nephrology (2009)}
   \item Jelliffe: \href{https://www.ncbi.nlm.nih.gov/pubmed/4748282}{Jelliffe, Annals of Internal Medicine (1973)}

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -144,6 +144,37 @@ test_that("calculate egfr works: ckd-epi", {
   )
 })
 
+test_that("calculate egfr works: ckd_epi_as_2021", {
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 80,
+        sex="female",
+        weight = 83,
+        scr = 0.8,
+        method = "ckd_epi_as_2021",
+        race="black",
+        verbose = FALSE
+      )$value
+    ),
+    114
+  )
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 80,
+        sex="male",
+        weight = 83,
+        scr = 0.8,
+        method = "ckd_epi_as_2021",
+        race="black",
+        verbose = FALSE
+      )$value
+    ),
+    92
+  )
+})
+
 
 test_that("calculate egfr works: mdrd, mdrd_original", {
   expect_equal(

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -140,7 +140,7 @@ test_that("calculate egfr works: ckd-epi", {
         verbose = FALSE
       )$value
     ),
-    123
+    109
   )
 })
 
@@ -157,7 +157,7 @@ test_that("calculate egfr works: ckd_epi_as_2021", {
         verbose = FALSE
       )$value
     ),
-    114
+    74
   )
   expect_equal(
     round(
@@ -171,7 +171,7 @@ test_that("calculate egfr works: ckd_epi_as_2021", {
         verbose = FALSE
       )$value
     ),
-    92
+    89
   )
 })
 
@@ -467,7 +467,7 @@ test_that("eGFR for ckd_epi_ignore_race", {
         verbose = FALSE
       )$value
     ),
-    134
+    136
   )
   expect_equal(
     calc_egfr(


### PR DESCRIPTION
When implementing the new CKD-EPI equation, i noticed our 2009 equations (with or without race) were also incorrect. This PR implements a corrected version.

Here is the original CKD-EPI publication:  https://pubmed.ncbi.nlm.nih.gov/19414839/
<img width="419" alt="image" src="https://user-images.githubusercontent.com/43552465/144520879-236ae99a-ad89-4b13-845b-a411184faed7.png">

Here is the updated CKD-EPI publication: https://www.nejm.org/doi/full/10.1056/NEJMoa2102953
Supplmentary info: https://www.nejm.org/doi/suppl/10.1056/NEJMoa2102953/suppl_file/nejmoa2102953_appendix.pdf
<img width="900" alt="image" src="https://user-images.githubusercontent.com/43552465/144521006-c2d23a41-03de-4a28-a100-5f63cac5dbc9.png">

From supplementary methods:
<img width="830" alt="image" src="https://user-images.githubusercontent.com/43552465/144521048-aac40b30-f792-4f6e-acd6-7a05f2c9ab9e.png">

eGFR calculations with the corrected method compared to the old method will be more different for male patients than for female patients. The difference based on CR is a little trickier to describe with a rule of thumb because their splines and normalization are rather confusing. From our unit test, it could have a difference of ~20%.
