### PR TITLE
RXR-626

### DIFF
--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -16,7 +16,8 @@
 #'   \item Schwartz revised / bedside
 #'   \item Jelliffe
 #'   \item Jelliffe for unstable renal function
-#'   \item Wright
+#'   \item Wright equation for eGFR in cancer patients, with creatinine measured
+#'     using the Jaffe assay.
 #' }
 #' Equations for estimation of eGFR from Cystatin C concentrations are available from the `calc_egfr_cystatin()` function.
 #'
@@ -394,7 +395,7 @@ egfr_wright <- function(age, bsa, sex, scr) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
-  ((74.4344 - (0.438914 * age)) * bsa * (1-(0.168*ifelse(sex == "male", 0, 1))))/scr
+  ((6580 - (38.8 * age)) * bsa * (1-(0.168 * (sex == "female"))))/(scr * 88.42)
 }
 
 #' @rdname calc_egfr

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -5,7 +5,9 @@
 #' approaches:
 #' \itemize{
 #'   \item Cockcroft-Gault (using weight, ideal body weight, or adjusted body weight)
-#'   \item C-G spinal cord injury
+#'   \item C-G spinal cord injury (using correction factot of 0.7, representing 
+#'     median correction point reported in the original publication (parapalegic
+#'     patients: 0.8; tetrapalegic patients: 0.6))
 #'   \item Revised Lund-Malmo
 #'   \item Modification of Diet in Renal Disease study (MDRD; 
 #'     with or without consideration of race, using either the original equation 
@@ -499,7 +501,7 @@ egfr_cockcroft_gault_sci <- function(sex, age, scr, weight) {
     return(NULL)
   }
   f_sex <- ifelse(sex == 'female', 0.85, 1)
-  2.3 * (f_sex * (140-age) / scr * (weight/72)) ^0.7
+  0.7 * (f_sex * (140-age) / scr * (weight/72))
 }
 
 #' @rdname calc_egfr

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -5,7 +5,7 @@
 #' approaches:
 #' \itemize{
 #'   \item Cockcroft-Gault (using weight, ideal body weight, or adjusted body weight)
-#'   \item C-G spinal cord injury (using correction factot of 0.7, representing 
+#'   \item C-G spinal cord injury (using correction factor of 0.7, representing 
 #'     median correction point reported in the original publication (parapalegic
 #'     patients: 0.8; tetrapalegic patients: 0.6))
 #'   \item Revised Lund-Malmo

--- a/man/calc_egfr.Rd
+++ b/man/calc_egfr.Rd
@@ -131,7 +131,9 @@ approaches:
   \item Schwartz
   \item Schwartz revised / bedside
   \item Jelliffe
-  \item Jelliffe for unstable renal function
+  \item Jelliffe for unstable renal function. Note that the 15% reduction in 
+    P_adj recommended for hemodialysis patients is not included in this 
+    implementation.
   \item Wright equation for eGFR in cancer patients, with creatinine measured
     using the Jaffe assay.
 }
@@ -176,7 +178,7 @@ calc_egfr(sex = "male", age = 50, scr = 1.1,
   \item Schwartz: \href{https://www.ncbi.nlm.nih.gov/pubmed/951142}{Schwartz et al., Pediatrics (1976)}
   \item Schwartz revised / bedside: \href{https://www.ncbi.nlm.nih.gov/pubmed/19158356}{Schwartz et al., Journal of the American Society of Nephrology (2009)}
   \item Jelliffe: \href{https://www.ncbi.nlm.nih.gov/pubmed/4748282}{Jelliffe, Annals of Internal Medicine (1973)}
-  \item Jelliffe for unstable renal function: \href{https://www.ncbi.nlm.nih.gov/pubmed/4748282}{Jelliffe, American Journal of Nephrology (2002)}
+  \item Jelliffe for unstable renal function: \href{https://pubmed.ncbi.nlm.nih.gov/12169862/}{Jelliffe, American Journal of Nephrology (2002)}
   \item Wright: \href{https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2363765/}{Wright et al., British Journal of Cancer (2001)}
 }
 }

--- a/man/calc_egfr.Rd
+++ b/man/calc_egfr.Rd
@@ -121,7 +121,9 @@ function) based on measured serum creatinine using one of the following
 approaches:
 \itemize{
   \item Cockcroft-Gault (using weight, ideal body weight, or adjusted body weight)
-  \item C-G spinal cord injury
+  \item C-G spinal cord injury (using correction factot of 0.7, representing 
+    median correction point reported in the original publication (parapalegic
+    patients: 0.8; tetrapalegic patients: 0.6))
   \item Revised Lund-Malmo
   \item Modification of Diet in Renal Disease study (MDRD; 
     with or without consideration of race, using either the original equation 

--- a/man/calc_egfr.Rd
+++ b/man/calc_egfr.Rd
@@ -121,7 +121,7 @@ function) based on measured serum creatinine using one of the following
 approaches:
 \itemize{
   \item Cockcroft-Gault (using weight, ideal body weight, or adjusted body weight)
-  \item C-G spinal cord injury (using correction factot of 0.7, representing 
+  \item C-G spinal cord injury (using correction factor of 0.7, representing 
     median correction point reported in the original publication (parapalegic
     patients: 0.8; tetrapalegic patients: 0.6))
   \item Revised Lund-Malmo

--- a/man/calc_egfr.Rd
+++ b/man/calc_egfr.Rd
@@ -132,7 +132,8 @@ approaches:
   \item Schwartz revised / bedside
   \item Jelliffe
   \item Jelliffe for unstable renal function
-  \item Wright
+  \item Wright equation for eGFR in cancer patients, with creatinine measured
+    using the Jaffe assay.
 }
 Equations for estimation of eGFR from Cystatin C concentrations are available from the `calc_egfr_cystatin()` function.
 }

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -123,7 +123,7 @@ test_that("calculate egfr works: cockroft_gault", {
         verbose = FALSE
       )$value
     ),
-    54
+    67
   )
 })
 

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -337,6 +337,122 @@ test_that("calculate egfr works: jelliffe", {
   )
 })
 
+test_that("calculate egfr works: jelliffe unstable", {
+  # The following tests match the equation against examples in the
+  # original publication. Please verify the original publication before
+  # adjusting test expectations.
+  
+  # Examples from Table 1
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 50,
+        sex= "male",
+        bsa = 1.73,
+        weight = 72,
+        scr = c(0.6, 0.6),
+        times = c(1, 2),
+        method = "jelliffe_unstable",
+        verbose = FALSE
+      )$value
+    ),
+    c(154, 154)
+  )
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 20,
+        sex= "male",
+        bsa = 1.73,
+        weight = 72,
+        scr = c(1, 1),
+        times = c(1, 2),
+        method = "jelliffe_unstable",
+        verbose = FALSE
+      )$value
+    ),
+    c(120, 120)
+  )
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 80,
+        sex= "female",
+        bsa = 1.73,
+        weight = 72,
+        scr = c(3, 3),
+        times = c(1, 2),
+        method = "jelliffe_unstable",
+        verbose = FALSE
+      )$value,
+      1
+    ),
+    c(17.4, 17.4)
+  )
+  
+  # Examples from Table 2
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 50,
+        sex = "male",
+        bsa = 1.73,
+        weight = 72,
+        scr = c(1, 0.6),
+        times = c(1, 2),
+        method = "jelliffe_unstable",
+        verbose = FALSE
+      )$value
+    ),
+    c(91, 125) # actually 124 in paper, but I think it's a rounding issue
+  )
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 50,
+        sex = "male",
+        bsa = 1.73,
+        weight = 72,
+        scr = c(1, 3),
+        times = c(1, 2),
+        method = "jelliffe_unstable",
+        verbose = FALSE
+      )$value
+    ),
+    c(91, 24)
+  )
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 50,
+        sex = "male",
+        bsa = 1.73,
+        weight = 72,
+        scr = c(0.6, 3),
+        times = c(1, 2),
+        method = "jelliffe_unstable",
+        verbose = FALSE
+      )$value
+    ),
+    c(154, 23)
+  )
+  expect_equal(
+    round(
+      calc_egfr(
+        age = 50,
+        sex = "male",
+        bsa = 1.73,
+        weight = 72,
+        scr = c(3, 1),
+        times = c(1, 2),
+        method = "jelliffe_unstable",
+        verbose = FALSE
+      )$value
+    ),
+    c(28, 64)
+  )
+})
+
 test_that("calculate egfr works: wright", {
   expect_equal(
     round(


### PR DESCRIPTION
I went through each egfr calculation method and referred to the cited publication. The Jeliffe unstable equation required a bit of a rework, but the values we calculate now match the examples in the paper. I refactored it to help debug it, so the lines of code changes are long, but the actual difference is just correctly calculating average serum creatinine and changing the sex multiplier.

The spinal cord injury CG also was wrong; I'm not sure exactly how that equation came to be that way, but I think my interpretation is correct.