### PR TITLE
RXR-819: return percentile when weight is right at 0.1st

### DIFF
--- a/R/pct_for_age_generic.R
+++ b/R/pct_for_age_generic.R
@@ -41,11 +41,11 @@ pct_for_age_generic <- function(age = NULL, value = NULL, sex = NULL, variable="
     p[length(p)] <- p[length(p)]/10 # 99.9
     p_txt <- paste0("pct_", p)
     if(value >= max(tmp)) {
-      message(paste0("Specified ", variable," > 99.9th percentile!"))
+      message(paste0("Specified ", variable," >= 99.9th percentile!"))
       pct <- list(percentile = 99.9)
     }
     if(value <= min(tmp)) {
-      message(paste0("Specified ", variable, " < 0.1th percentile!"))
+      message(paste0("Specified ", variable, " <= 0.1th percentile!"))
       pct <- list(percentile = 0.1)
     }
     if(is.null(pct$percentile)) {

--- a/R/pct_for_age_generic.R
+++ b/R/pct_for_age_generic.R
@@ -40,11 +40,11 @@ pct_for_age_generic <- function(age = NULL, value = NULL, sex = NULL, variable="
     p[1] <- p[1]/10 # 0.1
     p[length(p)] <- p[length(p)]/10 # 99.9
     p_txt <- paste0("pct_", p)
-    if(value > max(tmp)) {
+    if(value >= max(tmp)) {
       message(paste0("Specified ", variable," > 99.9th percentile!"))
       pct <- list(percentile = 99.9)
     }
-    if(value < min(tmp)) {
+    if(value <= min(tmp)) {
       message(paste0("Specified ", variable, " < 0.1th percentile!"))
       pct <- list(percentile = 0.1)
     }

--- a/R/pct_for_age_generic.R
+++ b/R/pct_for_age_generic.R
@@ -49,10 +49,16 @@ pct_for_age_generic <- function(age = NULL, value = NULL, sex = NULL, variable="
       pct <- list(percentile = 0.1)
     }
     if(is.null(pct$percentile)) {
-      data <- data.frame(cbind(
-        x = c(as.num(tmp[value <= as.num(tmp)][1]), tail(as.num(tmp[value > as.num(tmp)]),1)),
-        y = c(p[value <= as.num(tmp)][1], tail(p[value > as.num(tmp)],1))
-      ))
+      data <- data.frame(
+        x = c(
+          as.num(tmp[value <= as.num(tmp)][1]),
+          tail(as.num(tmp[value > as.num(tmp)]),1)
+        ),
+        y = c(
+          p[value <= as.num(tmp)][1],
+          tail(p[value > as.num(tmp)],1)
+        )
+      )
       # linearly scale between two values
       fit <- lm(y~x, data)
       par <- coef(fit)

--- a/tests/testthat/test_pct_for_age_generic.R
+++ b/tests/testthat/test_pct_for_age_generic.R
@@ -99,11 +99,13 @@ test_that("extreme percentiles capped to min and max", {
 })
 
 test_that("percentiles right at 0.1 return a value", {
-  res1 <- pct_for_age_generic(
-    age = 0.0349462365591398,
-    sex = "female",
-    value = 2.21,
-    variable = "weight"
+  res1 <- suppressMessages(
+    pct_for_age_generic(
+      age = 0.0349462365591398,
+      sex = "female",
+      value = 2.21,
+      variable = "weight"
+    )
   )
   expect_equal(res1, list(percentile = 0.1))
 })

--- a/tests/testthat/test_pct_for_age_generic.R
+++ b/tests/testthat/test_pct_for_age_generic.R
@@ -97,3 +97,13 @@ test_that("extreme percentiles capped to min and max", {
   expect_equal(pct1$percentile, 0.1)
   expect_equal(pct2$percentile, 99.9)
 })
+
+test_that("percentiles right at 0.1 return a value", {
+  res1 <- pct_for_age_generic(
+    age = 0.0349462365591398,
+    sex = "female",
+    value = 2.21,
+    variable = "weight"
+  )
+  expect_equal(res1, list(percentile = 0.1))
+})


### PR DESCRIPTION
We were returning `NA` as the percentile when the provided value was exactly at the 0.1st percentile. The reason was that `tail(as.num(tmp[value > as.num(tmp)]),1)` did not include any values, so the `data` data frame had only one row. Therefore when we fit `lm()` there was an intercept but the slope was `NA`, and when we added `as.num(par[1] + par[2]*value)` that produced `NA`. This fixes it by using `<=` and `>=`, rather than `<` and `>`, to check for values at the 99.9th or 0.1st percentile.