### PR TITLE
also extrapolate to true Cmax if last sample is at t=tau

### DIFF
--- a/R/nca.R
+++ b/R/nca.R
@@ -135,7 +135,7 @@ nca <- function (
       auc_t <- (auc_pre + auc_post)
       c_at_tmax <- data$time[1]
       c_at_tau  <- utils::tail(data$time,1)
-      if(tau > utils::tail(data$time,1)) {
+      if(tau > utils::tail(data$time,1) || extend) {
         # AUCtau is extrapolated to tau and back-extrapolated to tmax!
         c_at_tau <- utils::tail(trap$dv,1) * exp(-out$pk$kel * (tau-utils::tail(data$time,1)))
         if(extend) { # back-extrapolate to the true Cmax, to include that area too

--- a/tests/testthat/test_nca.R
+++ b/tests/testthat/test_nca.R
@@ -99,3 +99,32 @@ test_that("NCA with same DV at 3 different timepoints", {
     )/ res3$descriptive$auc_24 < 0.0001
   )
 })
+
+test_that("NCA with a sample at exactly tau still does peak extension", {
+  dat <- data.frame(
+    time = c(0, 3, 4, 6),
+    dv = c(0.001, 884, 586, 293)
+  )
+  out_extend <- nca(
+    data = dat,
+    dose = 58000,
+    tau = 6,           # exact time of last TDM
+    t_inf = 2,         # end of infusion is an hour before first sample
+    scale = list(auc = 0.001, conc = 1),
+    has_baseline = TRUE,
+    fit_samples = NULL,
+    extend = TRUE
+  )
+  out_no_extend <- nca(
+    data = dat,
+    dose = 58000,
+    tau = 6,           # exact time of last TDM
+    t_inf = 2,         # end of infusion is an hour before first sample
+    scale = list(auc = 0.001, conc = 1),
+    has_baseline = TRUE,
+    fit_samples = NULL,
+    extend = FALSE
+  )
+  expect_true(out_no_extend$descriptive$auc_t < out_extend$descriptive$auc_t)
+  expect_equal(out_extend$descriptive$auc_tau, out_extend$descriptive$auc_t)
+})


### PR DESCRIPTION
NCA measures the area under the curve using a log-linear approximation. Linear increase in drug during infusion, logarithmic decay If the first sample is not collected exactly at the end of infusion, we can extrapolate (using the slope of the log portion) to what the "true" cmax was. This is the meaning of the extend" argument.

The if/else statement here was poorly formed, such that if the final sample was measured at EXACTLY the end of the dosing interval, we actually didn't extrapolate back to Cmax. This PR fixes that and adds a unit test to ensure we continue to measure that area.