### PR TITLE
RXR-959: Replace `class() == ` with `inherits()`

### DIFF
--- a/R/calc_aki_stage.R
+++ b/R/calc_aki_stage.R
@@ -78,10 +78,10 @@ calc_aki_stage <- function (
 
   if(is.null(scr) && method !='prifle') stop("No serum creatinine values provided.")
   if(is.null(times) && method !='prifle') stop("No sample times (days) provided.")
-  if(class(times) == "Date") {
+  if(inherits(times, "Date")) {
     times <- as.numeric(difftime(times, min(times), units = "days"))
   }
-  if((!class(times[1]) %in% c("numeric","integer")) && method !='prifle') {
+  if(!inherits(times[1], c("numeric","integer")) && method !='prifle') {
     stop("`times` argument should be supplied either as days (numeric) or as Date class.")
   }
   if(length(scr) != length(times) && method !='prifle') stop("Serum creatinine values and vector of sample times should have same length.")
@@ -104,7 +104,7 @@ calc_aki_stage <- function (
     }
   }
   # pRIFLE does not require SCr
-  if(class(baseline_scr) == "character" && method !='prifle') {
+  if(inherits(baseline_scr, "character") && method !='prifle') {
     baseline_scr <- calc_baseline_scr(baseline_scr, 
                                       scr,
                                       times,

--- a/R/calc_baseline_scr.R
+++ b/R/calc_baseline_scr.R
@@ -16,7 +16,7 @@ calc_baseline_scr <- function(
       baseline_scr <- stats::median(scr, na.rm = TRUE)
       if(verbose) message("To calculate median baseline before treatment start need time of first dose. Using median over whole treatment period.")
     } else {
-      if((!class(first_dose_time) %in% c("numeric","integer"))) {
+      if((!inherits(first_dose_time, c("numeric","integer")))) {
         stop("`first_dose_times` argument should be supplied as numeric (hours).")
       }
       if(any(times <= first_dose_time)) {
@@ -48,7 +48,7 @@ calc_baseline_scr <- function(
   if(baseline_scr == "expected" && method !='prifle') {
     ## TODO: need to implement
   }
-  if(! class(baseline_scr) %in% c("numeric", "integer")) {
+  if(! inherits(baseline_scr, c("numeric", "integer"))) {
     stop("Requested baseline calculation method not recognized.")
   }
   

--- a/R/convert_creat_unit.R
+++ b/R/convert_creat_unit.R
@@ -9,7 +9,7 @@
 convert_creat_unit <- function(
   value = NULL,
   unit_in = "mg/dL") {
-  if(class(value) == "list" && !is.null(value$value) && !is.null(value$unit)) {
+  if(inherits(value, "list") && !is.null(value$value) && !is.null(value$unit)) {
     unit_in <- value$unit
     value <- value$value
   }

--- a/R/nca.R
+++ b/R/nca.R
@@ -98,7 +98,7 @@ nca <- function (
       baseline <- data$dv[1]
     }
     data_fit <- data
-    if(class(weights) == "function") { # transform f(y) to vector of weights
+    if(inherits(weights, "function")) { # transform f(y) to vector of weights
       weights <- do.call("weights", args = list(data_fit$dv))
     }
     

--- a/R/pk_1cmt_t12.R
+++ b/R/pk_1cmt_t12.R
@@ -12,8 +12,8 @@ pk_1cmt_t12 <- function(
   V = 30
 ) {
   ## conversions, if necessary
-  if(class(CL) == "list" && !is.null(CL$value)) { CL <- CL$value }
-  if(class(V) == "list"  && !is.null(V$value)) { V <- V$value }
+  if(inherits(CL, "list") && !is.null(CL$value)) { CL <- CL$value }
+  if(inherits(V, "list")  && !is.null(V$value)) { V <- V$value }
   kel <- CL / V
   t12 <- log(2) / kel
   return(t12)

--- a/R/pk_2cmt_t12.R
+++ b/R/pk_2cmt_t12.R
@@ -17,10 +17,10 @@ pk_2cmt_t12 <- function(
 ) {
   phase <- match.arg(phase)
   ## conversions, if necessary
-  if(class(CL) == "list" && !is.null(CL$value)) { CL <- CL$value }
-  if(class(V) == "list"  && !is.null(V$value)) { V <- V$value }
-  if(class(Q) == "list"  && !is.null(Q$value)) { Q <- Q$value }
-  if(class(V2) == "list" && !is.null(V2$value)) { V2 <- V2$value }
+  if(inherits(CL, "list") && !is.null(CL$value)) { CL <- CL$value }
+  if(inherits(V, "list")  && !is.null(V$value)) { V <- V$value }
+  if(inherits(Q, "list")  && !is.null(Q$value)) { Q <- Q$value }
+  if(inherits(V2, "list") && !is.null(V2$value)) { V2 <- V2$value }
   kel <- CL / V
   k12 <- Q / V
   k21 <- Q / V2

--- a/R/pk_2cmt_t12_interval.R
+++ b/R/pk_2cmt_t12_interval.R
@@ -20,10 +20,10 @@ pk_2cmt_t12_interval <- function(
   t_inf = NULL
 ) {
   ## conversions, if necessary
-  if(class(CL) == "list" && !is.null(CL$value)) { CL <- CL$value }
-  if(class(V) == "list"  && !is.null(V$value)) { V <- V$value }
-  if(class(Q) == "list"  && !is.null(Q$value)) { Q <- Q$value }
-  if(class(V2) == "list" && !is.null(V2$value)) { V2 <- V2$value }
+  if(inherits(CL, "list") && !is.null(CL$value)) { CL <- CL$value }
+  if(inherits(V, "list")  && !is.null(V$value)) { V <- V$value }
+  if(inherits(Q, "list")  && !is.null(Q$value)) { Q <- Q$value }
+  if(inherits(V2, "list") && !is.null(V2$value)) { V2 <- V2$value }
   if(!is.null(t_inf)) {
     conc <- pk_2cmt_inf_ss(t=c(t_inf, tau), dose = 1000, tau = tau, t_inf = t_inf, CL=CL, V=V, Q=Q, V2=V2)
   } else {


### PR DESCRIPTION
rhub returned a note about the use of `class()` in conditional statements (see screenshot in my comment on #38). This replaces `class() == ` with `inherits()`. I didn't want to add this commit directly to the branch without review since it does involve changes to the code.