### PR TITLE
RXR-1093: Add link to ds.insight-rx.com

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,15 @@ url: https://insightrx.github.io/clinPK/
 template:
   bootstrap: 5
 
+navbar:
+  structure:
+    right: [search, github, ds]
+  components:
+    ds:
+      href: https://ds.insight-rx.com/
+      icon: fa-home
+      aria-label: Home
+
 reference:
   - title: Anthropomorphic equations
     contents:


### PR DESCRIPTION
Adds a "home" icon that links to ds.insight-rx.com in the nav bar
<img width="1552" alt="Screen Shot 2022-07-11 at 10 55 39 AM" src="https://user-images.githubusercontent.com/4452678/178327424-cfb27682-083c-47fc-b3ab-ddf0b272e9a9.png">
 