### PR TITLE
RXR-1388: update convert_creat_unit and convert_albumin_unit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,6 @@ URL: https://github.com/InsightRX/clinPK,
         https://insightrx.github.io/clinPK/
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Suggests: testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/R/calc_creat_neo.R
+++ b/R/calc_creat_neo.R
@@ -9,8 +9,8 @@
 #' @param pma post-natal age in weeks
 #' @param digits number of digits to round to
 #' @examples
-#' calc_creat_neo(pma = 36)
-#' convert_creat_unit(calc_creat_neo(pma = 36))
+#' cr <- calc_creat_neo(pma = 36)
+#' convert_creat_unit(cr$value, unit_in = cr$unit, unit_out = "mg/dL")
 #' @export
 calc_creat_neo <- function (
   pma = NULL,

--- a/R/convert_albumin_unit.R
+++ b/R/convert_albumin_unit.R
@@ -35,7 +35,18 @@ convert_albumin_unit <- function(value,
     stop("length of unit_in must be either 1 or the same as values")
   }
 
-  conv <- c(g_dl = 1, `g/dl` = 1, g_l = .1, `g/l` = .1)
+  conv <- c(
+    g_dl         = 10,
+    `g/dl`       = 10,
+    g_l          = 1,
+    `g/l`        = 1,
+    `micromol/l` = 66.5,
+    micromol_l   = 66.5,
+    micromol     = 66.5,
+    mmol         = 66.5,
+    `mumol/l`    = 66.5,
+    `umol/l`     = 66.5
+  )
 
   list(
     value = value * unname(conv[unit_in]) / unname(conv[unit_out]),

--- a/R/convert_albumin_unit.R
+++ b/R/convert_albumin_unit.R
@@ -1,12 +1,11 @@
 #' Convert albumin from / to units
 #' 
-#' Accepted units are "g_l" or "g_dl". Arguments supplied to `value` and `from`
-#' units must be of the same length. "To" unit must be of length 1.
-#' 
-#' 
+#' Accepted units are "g_l" or "g_dl". Arguments supplied to `value` and
+#' `unit_in` units must be of the same length. "To" unit must be of length 1.
+#' #'
 #' @param value albumin measurements
-#' @param from from unit, e.g. `"g_l"`. 
-#' @param to to flow unit, e.g. `"g_dl"`
+#' @param unit_in from unit, e.g. `"g_l"`.
+#' @param unit_out to flow unit, e.g. `"g_dl"`
 #' 
 #' @examples 
 #' 
@@ -16,30 +15,30 @@
 #' ## vectorized
 #' convert_albumin_unit(
 #'   c(0.4, 2, 0.3), 
-#'   from = c("g_dl", "g_l", "g_dl"), 
-#'   to = c("g_l") 
+#'   unit_in = c("g_dl", "g_l", "g_dl"),
+#'   unit_out = c("g_l")
 #')
 #'   
 #' @export
-convert_albumin_unit <- function(
-  value,
-  from,
-  to
-) {
-  accept_units <- c("g_l", "g_dl")
-  if (!isTRUE(length(from) == length(value))) {
-    stop("length of 'from' units and number of albumin values should be equal")
-  } 
-  if (!all(from %in% accept_units)) {
-    stop("albumin measurement 'from' unit not recognized")
+convert_albumin_unit <- function(value,
+                                 unit_in = valid_units("serum_albumin"),
+                                 unit_out = valid_units("serum_albumin")) {
+  unit_in <- tolower(unit_in)
+  unit_out <- tolower(unit_out)
+  from <- match.arg(unit_in, several.ok = TRUE)
+  to <- match.arg(unit_out)
+  if (is.null(unit_out)) {
+    stop("Please provide output unit")
   }
-  if (length(to) != 1 || !to %in% accept_units) {
-    stop("albumin measurement 'to' unit not recognized")
+
+  if (length(unit_in) != length(value) && length(unit_in) != 1) {
+    stop("length of unit_in must be either 1 or the same as values")
   }
-  if (to == "g_l") {
-    value[from == "g_dl"] <- value[from == "g_dl"] * 10
-  } else {
-    value[from == "g_l"] <- value[from == "g_l"] * 0.1
-  }
-  value
+
+  conv <- c(g_dl = 1, `g/dl` = 1, g_l = .1, `g/l` = .1)
+
+  list(
+    value = value * unname(conv[unit_in]) / unname(conv[unit_out]),
+    unit = unit_out
+  )
 }

--- a/R/convert_creat_unit.R
+++ b/R/convert_creat_unit.R
@@ -1,32 +1,35 @@
 #' Convert creatinine to different unit
 #'
 #' @param value serum creatinine in either mg/dL or micromol/L
-#' @param unit_in unit, either `mg/dL` or `micromol/L`
+#' @param unit_in,unit_out unit, either `mg/dL` or `micromol/L`
 #' @examples
-#' convert_creat_unit(1)
-#' convert_creat_unit(88.42, unit_in = "micromol/l")
+#' convert_creat_unit(1, "mg/dL", "micromol/l")
+#' convert_creat_unit(88.42, "micromol/l", "mg/dL")
 #' @export
-convert_creat_unit <- function(
-  value = NULL,
-  unit_in = "mg/dL") {
-  if(inherits(value, "list") && !is.null(value$value) && !is.null(value$unit)) {
-    unit_in <- value$unit
-    value <- value$value
+convert_creat_unit <- function(value,
+                               unit_in = valid_units("scr"),
+                               unit_out = valid_units("scr")) {
+  unit_in <- tolower(unit_in)
+  unit_out <- tolower(unit_out)
+  if (length(unit_in) != length(value) && length(unit_in) != 1) {
+    stop("length of unit_in must be either 1 or the same as values")
   }
-  allowed <- valid_units("scr")
-  if(! all(tolower(unit_in) %in% allowed)) {
-    stop(paste0("Input unit needs to be one of ", paste(allowed, collapse = " ")))
-  }
-  if(tolower(unit_in) %in% c("mg/dl", "mg_dl")) {
-    out <- list(
-      value = value * 88.42,
-      unit = "micromol/L"
-    )
-  } else {
-    out <- list(
-      value = value / 88.42,
-      unit = "mg/dL"
-    )
-  }
-  return(out)
+  unit_in <- match.arg(unit_in, several.ok = TRUE)
+  unit_out <- match.arg(unit_out)
+
+  conv <- c(
+    `mg/dl`      = 1,
+    mg_dl        = 1,
+    `micromol/l` = 1 / 88.42,
+    micromol_l   = 1 / 88.42,
+    micromol     = 1 / 88.42,
+    mmol         = 1 / 88.42,
+    `mumol/l`    = 1 / 88.42,
+    `umol/l`     = 1 / 88.42
+  )
+
+  list(
+    value = value * unname(conv[unit_in]) / unname(conv[unit_out]),
+    unit = unit_out
+  )
 }

--- a/R/valid_units.R
+++ b/R/valid_units.R
@@ -19,6 +19,6 @@ valid_units <- function(
     weight = c("kg", "lb", "lbs", "pound", "pounds", "oz", "ounce", "ounces", "g", "gram", "grams"),
     scr = c("mg/dl", "mg_dl", "micromol/l", "micromol_l", "micromol", "mmol", "mumol/l", "umol/l"),
     age = c("yrs", "weeks", "days", "years"),
-    serum_albumin = c("g_l", "g/l", "g_dl", "g/dl")
+    serum_albumin = c("g_l", "g/l", "g_dl", "g/dl", "micromol/l", "micromol_l", "micromol", "mmol", "mumol/l", "umol/l")
   )
 }

--- a/R/valid_units.R
+++ b/R/valid_units.R
@@ -19,6 +19,6 @@ valid_units <- function(
     weight = c("kg", "lb", "lbs", "pound", "pounds", "oz", "ounce", "ounces", "g", "gram", "grams"),
     scr = c("mg/dl", "mg_dl", "micromol/l", "micromol_l", "micromol", "mmol", "mumol/l", "umol/l"),
     age = c("yrs", "weeks", "days", "years"),
-    serum_albumin = c("g_l", "g_dl")
+    serum_albumin = c("g_l", "g/l", "g_dl", "g/dl")
   )
 }

--- a/man/calc_creat_neo.Rd
+++ b/man/calc_creat_neo.Rd
@@ -20,6 +20,6 @@ based on data from Cuzzolin et al. (http://www.ncbi.nlm.nih.gov/pubmed/16773403)
 Rudd et al. (http://www.ncbi.nlm.nih.gov/pubmed/6838252)
 }
 \examples{
-calc_creat_neo(pma = 36)
-convert_creat_unit(calc_creat_neo(pma = 36))
+cr <- calc_creat_neo(pma = 36)
+convert_creat_unit(cr$value, unit_in = cr$unit, unit_out = "mg/dL")
 }

--- a/man/convert_albumin_unit.Rd
+++ b/man/convert_albumin_unit.Rd
@@ -4,18 +4,23 @@
 \alias{convert_albumin_unit}
 \title{Convert albumin from / to units}
 \usage{
-convert_albumin_unit(value, from, to)
+convert_albumin_unit(
+  value,
+  unit_in = c("g_l", "g_dl"),
+  unit_out = c("g_l", "g_dl")
+)
 }
 \arguments{
 \item{value}{albumin measurements}
 
-\item{from}{from unit, e.g. `"g_l"`.}
+\item{unit_in}{from unit, e.g. `"g_l"`.}
 
-\item{to}{to flow unit, e.g. `"g_dl"`}
+\item{unit_out}{to flow unit, e.g. `"g_dl"`}
 }
 \description{
-Accepted units are "g_l" or "g_dl". Arguments supplied to `value` and `from`
-units must be of the same length. "To" unit must be of length 1.
+Accepted units are "g_l" or "g_dl". Arguments supplied to `value` and
+`unit_in` units must be of the same length. "To" unit must be of length 1.
+#'
 }
 \examples{
 
@@ -25,8 +30,8 @@ convert_albumin_unit(0.6, "g_dl", "g_l")
 ## vectorized
 convert_albumin_unit(
   c(0.4, 2, 0.3), 
-  from = c("g_dl", "g_l", "g_dl"), 
-  to = c("g_l") 
+  unit_in = c("g_dl", "g_l", "g_dl"),
+  unit_out = c("g_l")
 )
   
 }

--- a/man/convert_albumin_unit.Rd
+++ b/man/convert_albumin_unit.Rd
@@ -6,8 +6,8 @@
 \usage{
 convert_albumin_unit(
   value,
-  unit_in = c("g_l", "g_dl"),
-  unit_out = c("g_l", "g_dl")
+  unit_in = valid_units("serum_albumin"),
+  unit_out = valid_units("serum_albumin")
 )
 }
 \arguments{

--- a/man/convert_creat_unit.Rd
+++ b/man/convert_creat_unit.Rd
@@ -4,17 +4,21 @@
 \alias{convert_creat_unit}
 \title{Convert creatinine to different unit}
 \usage{
-convert_creat_unit(value = NULL, unit_in = "mg/dL")
+convert_creat_unit(
+  value,
+  unit_in = valid_units("scr"),
+  unit_out = valid_units("scr")
+)
 }
 \arguments{
 \item{value}{serum creatinine in either mg/dL or micromol/L}
 
-\item{unit_in}{unit, either `mg/dL` or `micromol/L`}
+\item{unit_in, unit_out}{unit, either `mg/dL` or `micromol/L`}
 }
 \description{
 Convert creatinine to different unit
 }
 \examples{
-convert_creat_unit(1)
-convert_creat_unit(88.42, unit_in = "micromol/l")
+convert_creat_unit(1, "mg/dL", "micromol/l")
+convert_creat_unit(88.42, "micromol/l", "mg/dL")
 }

--- a/tests/testthat/test_convert_albumin_unit.R
+++ b/tests/testthat/test_convert_albumin_unit.R
@@ -26,4 +26,8 @@ test_that("basic conversions work", {
     convert_albumin_unit(c(60, 6), c("g_l", "g_dl"), "g_l"), 
     list(value = c(60, 60), unit = "g_l")
   )
+  expect_equal(
+    convert_albumin_unit(1, "micromol_l", "g_l"),
+    list(value = 66.5, unit = "g_l")
+  )
 })

--- a/tests/testthat/test_convert_albumin_unit.R
+++ b/tests/testthat/test_convert_albumin_unit.R
@@ -6,16 +6,24 @@ test_that("wrong units throw an error", {
 
 test_that("length mismatch throws error", {
   expect_error(convert_albumin_unit(70, NULL, "g_l"))
-  expect_error(convert_albumin_unit(c(70, 7), "g_dl", "g_l"))
+  expect_error(convert_albumin_unit(c(70, 7, 77), c("g_dl", "g_l"), "g_l"))
+})
+
+test_that("vectorized conversion works", {
+  res <- convert_albumin_unit(c(70, 7), "g_dl", "g_l")
+  expect_equal(
+    res,
+    list(value = c(700, 70), unit = "g_l")
+  )
 })
 
 test_that("basic conversions work", {
   expect_equal(
     convert_albumin_unit(c(60, 6), c("g_l", "g_dl"), "g_dl"), 
-    c(6, 6)
+    list(value = c(6, 6), unit = "g_dl")
   )
   expect_equal(
     convert_albumin_unit(c(60, 6), c("g_l", "g_dl"), "g_l"), 
-    c(60, 60)
+    list(value = c(60, 60), unit = "g_l")
   )
 })

--- a/tests/testthat/test_convert_creat_unit.R
+++ b/tests/testthat/test_convert_creat_unit.R
@@ -1,11 +1,63 @@
 test_that("convert_creat_unit converts correctly", {
   expect_equal(
-    round(convert_creat_unit(84, unit_in = "micromol/L")$value, 3),
+    round(
+      convert_creat_unit(
+        84,
+        unit_in = "micromol/L",
+        unit_out = "mg/dL"
+      )$value,
+      3
+    ),
     0.95
   )
   expect_equal(
-    round(convert_creat_unit(1.2, unit_in = "mg/dL")$value,3),
+    round(
+      convert_creat_unit(
+        1.2,
+        unit_in = "mg/dL",
+        unit_out = "micromol/L"
+      )$value,
+      3
+    ),
     106.104
   )
-  expect_equal(round(convert_creat_unit(1.2)$value,3), 106.104)
+})
+
+test_that("convert_creat_unit supports vectorized input", {
+  res1 <- convert_creat_unit(
+    c(84, 85, 86),
+    unit_in = "micromol/L",
+    unit_out = "mg/dL"
+  )
+  res2 <- convert_creat_unit(
+    c(84, 85, 1),
+    unit_in = c("micromol/L", "micromol/L", "mg/dL"),
+    unit_out = "mg/dL"
+  )
+  expect_equal(
+    res1,
+    list(
+      value = c(0.950011309658448, 0.961320968106763, 0.972630626555078),
+      unit = "mg/dl"
+    )
+  )
+  expect_equal(
+    res2,
+    list(value = c(0.950011309658448, 0.961320968106763, 1), unit = "mg/dl")
+  )
+})
+
+test_that("unsupported creat units throw an error", {
+  expect_error(convert_creat_unit(1, "foo", "mg/dl"))
+  expect_error(convert_creat_unit(1, "mg/dl", "foo"))
+})
+
+test_that("convert_creat_unit errors if values and unit_in are mismatched length", {
+  expect_error(
+    convert_creat_unit(
+      c(84, 85, 1),
+      unit_in = c("micromol/L", "micromol/L"),
+      unit_out = "mg/dL"
+    )
+  )
 })

--- a/tests/testthat/test_valid_units.R
+++ b/tests/testthat/test_valid_units.R
@@ -6,3 +6,22 @@ test_that("valid_units returns valid units", {
 test_that("valid_units errors if covariate not recognized", {
   expect_error(valid_units("foo"))
 })
+
+test_that("valid units for scr are consistent", {
+  expect_equal(
+    valid_units("scr"),
+    c(
+      "mg/dl",
+      "mg_dl",
+      "micromol/l",
+      "micromol_l",
+      "micromol",
+      "mmol",
+      "mumol/l",
+      "umol/l"
+    )
+  )
+  ## If this test is failing it is because we have updated the valid units for
+  ## scr. This test and comment are here to remind you to also update
+  ## convert_creat_unit() with whatever new units we want to support!
+})

--- a/tests/testthat/test_valid_units.R
+++ b/tests/testthat/test_valid_units.R
@@ -25,3 +25,24 @@ test_that("valid units for scr are consistent", {
   ## scr. This test and comment are here to remind you to also update
   ## convert_creat_unit() with whatever new units we want to support!
 })
+
+test_that("valid units for alb are consistent", {
+  expect_equal(
+    valid_units("serum_albumin"),
+    c(
+      "g_l",
+      "g/l",
+      "g_dl",
+      "g/dl",
+      "micromol/l",
+      "micromol_l",
+      "micromol",
+      "mmol",
+      "mumol/l",
+      "umol/l"
+    )
+  )
+  ## If this test is failing it is because we have updated the valid units for
+  ## serum_albumin. This test and comment are here to remind you to also update
+  ## convert_albumin_unit() with whatever new units we want to support!
+})


### PR DESCRIPTION
Updates `convert_creat_unit` and `convert_albumin_unit` to have more consistent behavior with each other and other conversion functions.
* Argument names are consistent: `value`, `unit_in`, `unit_out`
* Functions are vectorized over `value` and `unit_in`
* Return object is a list with elements `value` and `unit`

This is a breaking change for both functions. `convert_albumin_unit` returns a list instead of a single value, and `convert_creat_unit` takes a `unit_out` argument instead of assuming that the output unit based on the input unit. I think the consistency is worth the breaking change, but it will require updates in insightrxr and irxanalytics. 