### PR TITLE
RXR-573: Vectorize weight2kg over units as well as values

### DIFF
--- a/R/weight2kg.R
+++ b/R/weight2kg.R
@@ -11,19 +11,18 @@ weight2kg <- function(value = NULL, unit = NULL) {
   if(is.null(value)) {
     stop("No weight value specified.")
   }
-  if(!is.null(unit) && !is.na(unit)) {
-    if(tolower(unit) %in% valid_units("weight")) {
-      if(tolower(unit) %in% c("lb", "lbs", "pound", "pounds")) {
-        value <- value / 2.20462
-      }
-      if(tolower(unit) %in% c("oz", "ounce", "ounces")) {
-        value <- value / 35.274
-      }
-      if (tolower(unit) %in% c("g", "gram", "grams")) {
-        value <- value / 1000
-      }
+  if(!is.null(unit) && !any(is.na(unit))) {
+    if(all(tolower(unit) %in% valid_units("weight"))) {
+      div <- vector(mode = "numeric", length = length(unit))
+      div[which(tolower(unit) %in% c("lb", "lbs", "pound", "pounds"))] <- 2.20462
+      div[which(tolower(unit) %in% c("oz", "ounce", "ounces"))] <- 35.274
+      div[which(tolower(unit) %in% c("g", "gram", "grams"))] <- 1000
+      div[which(tolower(unit) %in% c("kg"))] <- 1
+
+      value <- value / div
     } else {
-      stop(paste0("Unit (", unit,") not recognized."))
+      invalid <- setdiff(unit, valid_units("weight"))
+      stop(paste0("Unit(s) (", paste0(invalid, collapse = ", "), ") not recognized."))
     }
   } else {
     stop("Weight unit not specified.")

--- a/tests/testthat/test_weight2kg.R
+++ b/tests/testthat/test_weight2kg.R
@@ -49,3 +49,25 @@ test_that("weight2kg supports capitalized units", {
   expect_equal(weight2kg(10, "LB"), 4.53592909)
   expect_equal(weight2kg(5, "KG"), 5)
 })
+
+test_that("weight2kg is vectorized over units", {
+  expect_equal(weight2kg(c(1000, 100), c("g", "lb")), c(1, 45.3592909))
+  expect_equal(weight2kg(c(400, 500), c("oz", "oz")), c(11.3397970176, 14.1747462720))
+})
+
+test_that("weight2kg errors if any units are invalid", {
+  expect_error(weight2kg(c(100, 100, 100), c("lb", "foo", "bar")))
+})
+
+test_that("normal R recycling happens if values and units are different length", {
+  expect_warning(
+    expect_equal(
+      weight2kg(c(100, 100, 100), c("lb", "kg")),
+      c(45.3592909, 100, 45.3592909)
+    )
+  )
+  expect_equal(
+    weight2kg(100, c("g", "kg")),
+    c(0.1, 100)
+  )
+})


### PR DESCRIPTION
Allows user to pass a vector of units instead of just 1. We already supported vectors of values.

I opted to use R's default behavior for vectorized operations when the vectors are different lengths, but we could also be more strict and require that the units vector is either length 1 or the same length as the values vector.