### PR TITLE
RXR-1677 extend unit conversion creat

### DIFF
--- a/R/convert_creat_unit.R
+++ b/R/convert_creat_unit.R
@@ -25,7 +25,9 @@ convert_creat_unit <- function(value,
     micromol     = 1 / 88.42,
     mmol         = 1 / 88.42,
     `mumol/l`    = 1 / 88.42,
-    `umol/l`     = 1 / 88.42
+    `mumol_l`    = 1 / 88.42,
+    `umol/l`     = 1 / 88.42,
+    `umol_l`     = 1 / 88.42
   )
 
   list(

--- a/R/valid_units.R
+++ b/R/valid_units.R
@@ -17,7 +17,7 @@ valid_units <- function(
     cov,
     height = c("cm", "inch", "inches", "in"),
     weight = c("kg", "lb", "lbs", "pound", "pounds", "oz", "ounce", "ounces", "g", "gram", "grams"),
-    scr = c("mg/dl", "mg_dl", "micromol/l", "micromol_l", "micromol", "mmol", "mumol/l", "umol/l"),
+    scr = c("mg/dl", "mg_dl", "micromol/l", "micromol_l", "micromol", "mmol", "mumol/l", "umol/l", "mumol_l", "umol_l"),
     age = c("yrs", "weeks", "days", "years"),
     serum_albumin = c("g_l", "g/l", "g_dl", "g/dl", "micromol/l", "micromol_l", "micromol", "mmol", "mumol/l", "umol/l")
   )

--- a/tests/testthat/test_convert_creat_unit.R
+++ b/tests/testthat/test_convert_creat_unit.R
@@ -30,8 +30,8 @@ test_that("convert_creat_unit supports vectorized input", {
     unit_out = "mg/dL"
   )
   res2 <- convert_creat_unit(
-    c(84, 85, 1),
-    unit_in = c("micromol/L", "micromol/L", "mg/dL"),
+    c(84, 85, 1, 84),
+    unit_in = c("micromol/L", "micromol/L", "mg/dL", "umol_l"),
     unit_out = "mg/dL"
   )
   expect_equal(
@@ -43,7 +43,7 @@ test_that("convert_creat_unit supports vectorized input", {
   )
   expect_equal(
     res2,
-    list(value = c(0.950011309658448, 0.961320968106763, 1), unit = "mg/dl")
+    list(value = c(0.950011309658448, 0.961320968106763, 1, 0.950011309658448), unit = "mg/dl")
   )
 })
 


### PR DESCRIPTION
We were not supporting mumol_l and umol_l. This was causing bug for some models, e.g. in tacrolimus children the Andrews model, because range defined in model as umol_l which we didn’t support yet. I propose to add these to the allowed conversions (since we're also supporting "mumol/l" and "umol/l"), but at the same time also unify the unit label we use in the model metadata (to "micromol/l", which is what we use most often).