### PR TITLE
RXR-1877: Fixes for pkgdown

### DIFF
--- a/R/convert_conc_unit.R
+++ b/R/convert_conc_unit.R
@@ -3,6 +3,7 @@
 #' Lower-level function called by `convert_creat_unit()`,
 #' `convert_albumin_unit()`, and others.
 #'
+#' @keywords internal
 #' @seealso valid_units
 #' @param value Value to convert
 #' @param unit_in Input unit

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -51,6 +51,7 @@ reference:
       - convert_albumin_unit
       - convert_creat_assay
       - convert_creat_unit
+      - convert_bilirubin_unit
   - title: PK compartmental equations
     desc: Functions to simulate concentrations for linear PK models.
     contents:

--- a/man/convert_conc_unit.Rd
+++ b/man/convert_conc_unit.Rd
@@ -22,3 +22,4 @@ Lower-level function called by `convert_creat_unit()`,
 \seealso{
 valid_units
 }
+\keyword{internal}


### PR DESCRIPTION
Adds `convert_bilirubin_unit` to the pkgdown reference page, and marks `convert_conc_unit` as internal (it's unexported, but documented) so that pkgdown doesn't complain about these functions being missing.