### PR TITLE
closes #60

### DIFF
--- a/R/pk_2cmt_inf.R
+++ b/R/pk_2cmt_inf.R
@@ -35,7 +35,7 @@ pk_2cmt_inf <- function(
   A <- (1/V) * (alpha - (Q/V2))/(alpha-beta)
   B <- (1/V) * ((beta - Q/V2)/(beta-alpha))
 
-  for(i in 1:(length(unq_dos)-1)) {
+  for(i in seq(unq_dos)) {
     sel <- n_dos >= i-1
     tmp <- dat[sel,]
     tmp$t <- tmp$t - (i-1)*tau

--- a/tests/testthat/test_pk_2cmt_inf.R
+++ b/tests/testthat/test_pk_2cmt_inf.R
@@ -12,7 +12,17 @@ test_that("PK 2cmt infusion over time", {
     Q = 2.28,
     V2 = 58.56
   )
-  expect_named(res, c("t", "dv"))
+  res_t24 <- pk_2cmt_inf(
+    t = 24,
+    dose = 1000,
+    tau = 12,
+    t_inf = 2,
+    CL = 2.99,
+    V = 54,
+    Q = 2.28,
+    V2 = 58.56
+  )
+expect_named(res, c("t", "dv"))
   expect_s3_class(res, "data.frame")
   expect_equal(res$t, 0:24)
   expect_equal(
@@ -22,6 +32,14 @@ test_that("PK 2cmt infusion over time", {
   expect_equal(
     round(res$dv[13:18], 2), 
     c(7.14, 15.46, 23.03, 21.09, 19.36, 17.81)
+  )
+  expect_equal(
+    res[res$t ==  24,]$dv,
+    res_t24$dv
+  )
+  expect_equal(
+    res[res$t ==  24,]$t,
+    res_t24$t
   )
 })
 


### PR DESCRIPTION
addresses unexpected behaviour of `pk_2cmt_inf` relative to `pk_2cmt_bolus`, `pk_1cmt_inf`, `pk_1cmt_bolus`, where function call to individual timepoints do not match values from ranges:

```
> pk_1cmt_inf()
    t       dv
1   0 0.000000
2   1 1.586043
3   2 3.021154
4   3 2.733653
5   4 2.473512
6   5 2.238126
7   6 2.025140
8   7 1.832423
9   8 1.658045
10  9 1.500261
11 10 1.357492
12 11 1.228310
13 12 1.111420
14 13 2.591698
15 14 3.931108
16 15 3.557014
17 16 3.218519
18 17 2.912237
19 18 2.635101
20 19 2.384338
21 20 2.157438
22 21 1.952131
23 22 1.766361
24 23 1.598269
25 24 1.446174
```

```
> pk_1cmt_inf(t = 24)
   t       dv
1 24 1.446174
```

```
> pk_2cmt_inf()
    t        dv
1   0 0.0000000
2   1 3.0736916
3   2 2.6196162
4   3 2.2488519
5   4 1.9451497
6   5 1.6954759
7   6 1.4893737
8   7 1.3184518
9   8 1.1759745
10  9 1.0565334
11 10 0.9557839
12 11 0.8702344
13 12 0.7970773
14 13 3.8077451
15 14 3.2989601
16 15 2.8803340
17 16 2.5344348
18 17 2.2472729
19 18 2.0076180
20 19 1.8064519
21 20 1.6365298
22 21 1.4920287
23 22 1.3682655
24 23 1.2614716
25 24 1.1686115
```

```
> pk_2cmt_inf(t = 24)
   t        dv
1 24 0.5812193
```

```
R version 4.3.1 (2023-06-16)
Platform: x86_64-apple-darwin13.4.0 (64-bit)
Running under: macOS Big Sur ... 10.16
clinPK_0.11.1
```
