### PR TITLE
tidier scr unit conversion

### DIFF
--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -156,7 +156,8 @@ calc_egfr <- function (
     scr_unit <- rep(scr_unit, length(scr))
   }
   scr_unit <- tolower(gsub("%2F", "/", scr_unit))
-  scr[scr_unit != "mg/dl"] <- scr[scr_unit != "mg/dl"] / 88.4
+  mol_unit <- grepl("mol", scr_unit)
+  scr[mol_unit] <- scr[mol_unit] / 88.4
 
   # ---- Format Sex
   sex <- ifelse(is.nil(sex), '', tolower(sex))

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -156,8 +156,7 @@ calc_egfr <- function (
     scr_unit <- rep(scr_unit, length(scr))
   }
   scr_unit <- tolower(gsub("%2F", "/", scr_unit))
-  mol_unit <- grepl("mol", scr_unit)
-  scr[mol_unit] <- scr[mol_unit] / 88.4
+  scr <- convert_creat_unit(scr, scr_unit, "mg/dl")$value
 
   # ---- Format Sex
   sex <- ifelse(is.nil(sex), '', tolower(sex))

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -713,7 +713,7 @@ test_that("calc_egfr converts scr appropriately", {
     age = 40,
     sex = "female",
     weight = 80,
-    scr = 1 * 88.4,
+    scr = 1 * 10e3/113.12,
     scr_unit = "micromol_l",
     method = "cockcroft_gault",
     verbose = FALSE

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -689,3 +689,36 @@ test_that("calc_egfr warns and returns NULL if sex isn't supported", {
   )
   expect_null(res$value)
 })
+
+test_that("calc_egfr converts scr appropriately", {
+  res1 <- calc_egfr(
+    age = 40,
+    sex = "female",
+    weight = 80,
+    scr = 1,
+    scr_unit = "MG/DL",
+    method = "cockcroft_gault",
+    verbose = FALSE
+  )
+  res2 <- calc_egfr(
+    age = 40,
+    sex = "female",
+    weight = 80,
+    scr = 1,
+    scr_unit = "mg_dl",
+    method = "cockcroft_gault",
+    verbose = FALSE
+  )
+  res3 <- calc_egfr(
+    age = 40,
+    sex = "female",
+    weight = 80,
+    scr = 1 * 88.4,
+    scr_unit = "micromol_l",
+    method = "cockcroft_gault",
+    verbose = FALSE
+  )
+  expect_equal(res1$value, 94.444444)
+  expect_equal(res2$value, 94.444444)
+  expect_equal(res3$value, 94.444444)
+})


### PR DESCRIPTION
in `valid_units("scr")` we accept either "mg_dl" or "mg/dl", but we convert from molar mass if the unit is anything but "mg/dl". This PR instead looks for the presence of "mol" in the unit to identify if the units are molar and should be converted, catching a possible edge case.

this does not affect any production code since we standardize units elsewhere, however I think this is a cleaner approach.

``` r
clinPK::valid_units("scr")
#>  [1] "mg/dl"      "mg_dl"      "micromol/l" "micromol_l" "micromol"  
#>  [6] "mmol"       "mumol/l"    "umol/l"     "mumol_l"    "umol_l"
```

<sup>Created on 2024-09-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>