### PR TITLE
Handling for when scr_unit is missing-y

### DIFF
--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -146,7 +146,7 @@ calc_egfr <- function (
   }
 
   # ---- Convert Creatinine
-  if (is.null(scr_unit)) {
+  if (is.null(scr_unit) || length(scr_unit) == 0 || is.na(scr_unit)) {
     if(verbose) message("Creatinine unit not specified, assuming mg/dL.")
     scr_unit <- "mg/dl"
   } else if (!(all(tolower(scr_unit) %in% valid_units("scr")))) {

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -146,7 +146,7 @@ calc_egfr <- function (
   }
 
   # ---- Convert Creatinine
-  if (is.null(scr_unit) || length(scr_unit) == 0 || is.na(scr_unit)) {
+  if (is.null(scr_unit) || length(scr_unit) == 0 || all(is.na(scr_unit))) {
     if(verbose) message("Creatinine unit not specified, assuming mg/dL.")
     scr_unit <- "mg/dl"
   } else if (!(all(tolower(scr_unit) %in% valid_units("scr")))) {

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -722,3 +722,63 @@ test_that("calc_egfr converts scr appropriately", {
   expect_equal(res2$value, 94.444444)
   expect_equal(res3$value, 94.444444)
 })
+
+test_that("missing scr_units handled well", {
+  # with unit specified as default
+  expect_res <- calc_egfr(
+    age = 40,
+    sex = "male",
+    weight = 80,
+    scr = 3,
+    scr_unit = NA,
+    method = "cockcroft_gault",
+    verbose = FALSE,
+    max_value = 150,
+  )$value
+  
+  # with character(0)
+  expect_message(
+    res1 <- calc_egfr(
+      age = 40,
+      sex = "male",
+      weight = 80,
+      scr = 3,
+      scr_unit = character(0),
+      method = "cockcroft_gault",
+      max_value = 150,
+    )$value,
+    "Creatinine unit not specified, assuming mg/dL."
+  )
+  
+  # with NA
+  expect_message(
+    res2 <- calc_egfr(
+      age = 40,
+      sex = "male",
+      weight = 80,
+      scr = 3,
+      scr_unit = NA,
+      method = "cockcroft_gault",
+      max_value = 150,
+    )$value,
+    "Creatinine unit not specified, assuming mg/dL."
+  )
+  
+  # with NULL
+  expect_message(
+    res3 <- calc_egfr(
+      age = 40,
+      sex = "male",
+      weight = 80,
+      scr = 3,
+      scr_unit = NULL,
+      method = "cockcroft_gault",
+      max_value = 150,
+    )$value,
+    "Creatinine unit not specified, assuming mg/dL."
+  )
+  
+  expect_equal(res1, expect_res)
+  expect_equal(res2, expect_res)
+  expect_equal(res3, expect_res)
+})


### PR DESCRIPTION
In the change I made in https://github.com/InsightRX/clinPK/pull/63, `convert_creat_unit` would error if `scr_unit` was a vector of length 0: 

> Error in match.arg(unit_in, several.ok = TRUE) : 
  'arg' must be of length >= 1


This PR adds additional error handling, falling back to the same default as a NULL scr_unit in the case of a vector of length 0 or where all supplied values are NA.