### PR TITLE
RXR-2892: fix coefficient for Boer equation

### DIFF
--- a/R/calc_lbw.R
+++ b/R/calc_lbw.R
@@ -44,7 +44,7 @@ calc_lbw <- function (
     } else {
       if(method == "boer") {
         if(sex == "male") {
-          lbm <-  0.407 * weight + 0.237 * height - 19.2
+          lbm <-  0.407 * weight + 0.267 * height - 19.2
         } else {
           lbm <-  0.252 * weight + 0.473 * height - 48.3
         }

--- a/tests/testthat/test_calc_lbw.R
+++ b/tests/testthat/test_calc_lbw.R
@@ -17,3 +17,14 @@ test_that("LBW calculation works", {
     class(calc_lbw(weight = 50, height = 150, sex = "male")) == "list"
   )
 })
+
+test_that("LBW calculation works, boer", {
+  expect_equal(
+    calc_lbw(weight = 65, height = 155, sex = "male", method = "boer")$value,
+    48.6
+  )
+  expect_equal(
+    calc_lbw(weight = 65, height = 155, sex = "female", method = "boer")$value,
+    41.4
+  )
+})


### PR DESCRIPTION
A recent review of the original Boer paper unearthed a small typo in the equation for males for the Boer equation for LBW. I have implemented a fix and cross-referenced our values against another online calculator: https://www.mymathtables.com/calculator/health/lbm-equation-boer-hume-james-calculator.html

The impact of this error should be relatively low. It is not widely used.