### PR TITLE
RXR-3138: improve handling of vectorization/recycling in `calc_*` functions

### DIFF
--- a/R/calc_dosing_weight.R
+++ b/R/calc_dosing_weight.R
@@ -26,18 +26,21 @@ calc_dosing_weight <- function(weight, height, age, sex, verbose = TRUE, ...) {
   }
   ibw <- calc_ibw(weight = weight, height = height, age = age, sex = sex)
   abw <- calc_abw(weight = weight, ibw = ibw, ...)
-  wt_chosen <- ibw
-  weight_type <- "Ideal BW"
-  if(weight > (ibw * 1.2)) {
-    weight_type <- "Adjusted BW"
-    wt_chosen <- abw
-    if(verbose) message("Using adjusted body weight.")
-  } else if(weight < ibw) {
-    weight_type <- "Total BW"
-    wt_chosen <- weight
-    if(verbose) message("Using total body weight.")
-  } else {
-    if(verbose) message("Using ideal body weight.")
+  weight_type <- ifelse(
+    weight > ibw * 1.2,
+    "Adjusted BW",
+    ifelse(
+      weight < ibw,
+      "Total BW",
+      "Ideal BW"
+    )
+  )
+  wt_chosen <- ifelse(weight > ibw * 1.2, abw, ifelse(weight < ibw, weight, ibw))
+  if (verbose) {
+    types <- unique(weight_type)
+    if ("Adjusted BW" %in% types) message("Using adjusted body weight.")
+    if ("Total BW" %in% types) message("Using total body weight.")
+    if ("Ideal BW" %in% types) message("Using ideal body weight.")
   }
   return(list(value = wt_chosen, unit = "kg", type = weight_type))
 }

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -116,7 +116,6 @@ calc_egfr <- function (
   ...
 ){
 
-
   # Format output units
   # ---- Relative eGFR?
   if (is.nil(relative)) {
@@ -132,6 +131,16 @@ calc_egfr <- function (
   method <- names(cov_reqs)
   cov_reqs <- cov_reqs[[1]]
 
+  # Check for inconsistent vector lengths
+  check_input_lengths(
+    sex = sex,
+    age = age,
+    scr = scr,
+    weight = weight,
+    height = height,
+    bsa = bsa
+  )
+  
   # Convert units, tidy covariates, calculate intermediates if required
   # -------------------------------------------------------------------
 
@@ -159,8 +168,8 @@ calc_egfr <- function (
   scr <- convert_creat_unit(scr, scr_unit, "mg/dl")$value
 
   # ---- Format Sex
-  sex <- ifelse(is.nil(sex), '', tolower(sex))
-
+  sex <- if (is.nil(sex)) '' else tolower(sex)
+  
   # Confirm Required Covariates Are Present
   # ---------------------------------------
   calculate_egfr <- check_covs_available(
@@ -394,7 +403,7 @@ calc_egfr <- function (
 }
 
 egfr_wright <- function(age, bsa, sex, scr) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -402,7 +411,7 @@ egfr_wright <- function(age, bsa, sex, scr) {
 }
 
 egfr_jelliffe <- function(age, sex, bsa, scr) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -410,7 +419,7 @@ egfr_jelliffe <- function(age, sex, bsa, scr) {
 }
 
 egfr_jelliffe_unstable <- function(weight, times, scr, age, sex) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -456,7 +465,7 @@ egfr_jelliffe_unstable <- function(weight, times, scr, age, sex) {
 #'   coefficient (TRUE) or the 2006 coefficient (FALSE), which was updated for 
 #'   standardization of the creatinine assay.
 egfr_mdrd <- function(sex, race, scr, age, use_race, original_expression) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -467,7 +476,7 @@ egfr_mdrd <- function(sex, race, scr, age, use_race, original_expression) {
 }
 
 egfr_ckd_epi <- function(sex, race, scr, age, use_race) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -479,7 +488,7 @@ egfr_ckd_epi <- function(sex, race, scr, age, use_race) {
 }
 
 egfr_ckd_epi_as_2021 <- function(sex, scr, age) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -490,7 +499,7 @@ egfr_ckd_epi_as_2021 <- function(sex, scr, age) {
 }
 
 egfr_cockcroft_gault_sci <- function(sex, age, scr, weight) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -499,7 +508,7 @@ egfr_cockcroft_gault_sci <- function(sex, age, scr, weight) {
 }
 
 egfr_cockcroft_gault <- function(sex, age, scr, weight) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -508,7 +517,7 @@ egfr_cockcroft_gault <- function(sex, age, scr, weight) {
 }
 
 egfr_malmo_lund <- function(sex, age, scr) {
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
@@ -531,16 +540,14 @@ egfr_bedside_schwartz <- function(age, height, scr, verbose) {
 }
 
 egfr_schwartz <- function(age, preterm, sex, height, scr) {
-  if (age < 1 ) {
-    k <- ifelse(preterm, 0.33, 0.45)
-  } else if (age > 13) {
-    if (!sex %in% c("male", "female")) {
-      warning("This method requires sex to be one of 'male' or 'female'.")
-      return(NULL)
-    }
-    k <- ifelse(sex == 'male', 0.7,  0.55)
-  } else {
-    k <- 0.55
+  if (any(!sex %in% c("male", "female"))) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
   }
+  k <- ifelse(
+    age < 1,
+    ifelse(preterm, 0.33, 0.45),
+    ifelse(age > 13 & sex == "male", 0.7, 0.55)
+  )
   (k * height) / scr
 }

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -116,22 +116,52 @@ calc_egfr <- function (
   ...
 ){
 
-  # Format output units
-  # ---- Relative eGFR?
-  if (is.nil(relative)) {
+  # Format output units -------------------------------------------------------
+  if (is.nil(relative)) { # Relative eGFR?
     # By default, assume true, since most equations report in units of /1.73m2.
     # Cockcroft-Gault and derived formulae do not report in relative units, but
     # do not require bsa to convert.
     relative <- ifelse(grepl('cockcroft_gault', method), FALSE, TRUE)
   }
   
-  # Extract required covariates and tidied method name
-  # --------------------------------------------------
+  # Extract required covariates and tidied method name ------------------------
   cov_reqs <- egfr_cov_reqs(method, relative)
   method <- names(cov_reqs)
   cov_reqs <- cov_reqs[[1]]
-
-  # Check for inconsistent vector lengths
+  
+  # Calculate intermediate covariates if required -----------------------------
+  
+  ## Calculate BSA ----
+  if("bsa" %in% cov_reqs && is.nil(bsa)) { 
+    calculate_egfr <- check_covs_available(c('height', 'weight'), 
+                                           list(height = height, weight = weight), fail = fail)
+    if(!fail && !calculate_egfr) {
+      return(FALSE)
+    }
+    bsa <- calc_bsa(weight, height, bsa_method)$value
+  }
+  
+  # Confirm required covariates are present -----------------------------------
+  calculate_egfr <- check_covs_available(
+    cov_reqs,
+    list(
+      age = age,
+      sex = sex,
+      creat = scr,
+      weight = weight,
+      height = height,
+      bsa = bsa,
+      race = race,
+      preterm = preterm
+    ),
+    verbose = TRUE, 
+    fail = fail
+  )
+  if (!(calculate_egfr)) {
+    return(FALSE)
+  }
+  
+  # Check for inconsistent vector lengths -------------------------------------
   check_input_lengths(
     sex = sex,
     age = age,
@@ -141,20 +171,9 @@ calc_egfr <- function (
     bsa = bsa
   )
   
-  # Convert units, tidy covariates, calculate intermediates if required
-  # -------------------------------------------------------------------
+  # Convert units, tidy covariates --------------------------------------------
 
-  # ---- Calculate BSA
-  if("bsa" %in% cov_reqs && is.nil(bsa)) { 
-    calculate_egfr <- check_covs_available(c('height', 'weight'), 
-                          list(height = height, weight = weight), fail = fail)
-    if(!fail && !calculate_egfr) {
-      return(FALSE)
-    }
-    bsa <- calc_bsa(weight, height, bsa_method)$value
-  }
-
-  # ---- Convert Creatinine
+  ## Convert Creatinine ----
   if (is.null(scr_unit) || length(scr_unit) == 0 || all(is.na(scr_unit))) {
     if(verbose) message("Creatinine unit not specified, assuming mg/dL.")
     scr_unit <- "mg/dl"
@@ -167,32 +186,14 @@ calc_egfr <- function (
   scr_unit <- tolower(gsub("%2F", "/", scr_unit))
   scr <- convert_creat_unit(scr, scr_unit, "mg/dl")$value
 
-  # ---- Format Sex
+  ## Format Sex ----
   sex <- if (is.nil(sex)) '' else tolower(sex)
-  
-  # Confirm Required Covariates Are Present
-  # ---------------------------------------
-  calculate_egfr <- check_covs_available(
-    cov_reqs,
-    list(
-      age = age,
-      sex = sex,
-      creat = scr,
-      weight = weight,
-      height = height,
-      bsa = bsa,
-      race = race,
-      preterm = preterm
-      ),
-    verbose = TRUE, 
-    fail = fail
-  )
-  if (!(calculate_egfr)) {
-    return(FALSE)
+  if ("sex" %in% cov_reqs && !all(sex %in% c("male", "female"))) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
   }
 
-  # Select Weight for eGFR
-  # ----------------------
+  ## Select Weight for eGFR ----
   if (grepl('cockcroft_gault_', method)) {
 
     if (grepl('_ideal', method)) {
@@ -221,8 +222,7 @@ calc_egfr <- function (
     weight_for_egfr <- "Total BW"
   }
 
-  # Calculate eGFR
-  # --------------
+  # Calculate eGFR ------------------------------------------------------------
 
   if (grepl("cockcroft_gault(.*)(?<!sci)$", method, perl = TRUE)) {
     method <- "cockcroft_gault"
@@ -332,8 +332,7 @@ calc_egfr <- function (
     NULL
   )
 
-  # Format Output
-  # -------------
+  # Format output -------------------------------------------------------------
   unit <- tolower(unit_out)
 
   if (is.null(crcl)) {
@@ -351,7 +350,7 @@ calc_egfr <- function (
     )
   }
 
-  # --- Convert to relative if required
+  ## Convert to relative if required ----
   if (!relative & !grepl('cockcroft_gault', method)) {
     crcl <- relative2absolute_bsa(crcl, bsa)[["value"]]
   } else if (relative & !grepl('cockcroft_gault', method)){
@@ -360,13 +359,13 @@ calc_egfr <- function (
     unit <- paste0(unit, "/1.73m^2")
     crcl <- absolute2relative_bsa(crcl, bsa)[["value"]]
   }
-  # --- Convert to /h or to L if required
+  ## Convert to /h or to L if required ----
   conversion_factor <- 1
   conversion_factor <- ifelse(grepl('/hr', unit), conversion_factor * 60, conversion_factor)
   conversion_factor <- ifelse(grepl('^l', unit), conversion_factor / 1000, conversion_factor)
   crcl <- conversion_factor * crcl
 
-# --- Check min/max censoring
+  ## Check min/max censoring ----
   capped <- list()
   if(!is.null(min_value)){
     idx <- crcl < min_value
@@ -387,9 +386,7 @@ calc_egfr <- function (
     }
   }
 
-  # Return Output
-  # -------------
-
+  # Return Output -------------------------------------------------------------
   return(list(
     value = crcl,
     age = age,
@@ -403,26 +400,14 @@ calc_egfr <- function (
 }
 
 egfr_wright <- function(age, bsa, sex, scr) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   ((6580 - (38.8 * age)) * bsa * (1-(0.168 * (sex == "female"))))/(scr * 88.42)
 }
 
 egfr_jelliffe <- function(age, sex, bsa, scr) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   ((98 - 0.8*(age - 20)) * (1 - 0.01 * ifelse(sex == "male", 0, 1)) * bsa/1.73) / scr
 }
 
 egfr_jelliffe_unstable <- function(weight, times, scr, age, sex) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   vol <- 4 * weight
 
   # for times, if null or negative or mismatch in times/scr length, assume one 
@@ -465,10 +450,6 @@ egfr_jelliffe_unstable <- function(weight, times, scr, age, sex) {
 #'   coefficient (TRUE) or the 2006 coefficient (FALSE), which was updated for 
 #'   standardization of the creatinine assay.
 egfr_mdrd <- function(sex, race, scr, age, use_race, original_expression) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   coeff <- ifelse(original_expression, 186, 175)
   f_sex <- ifelse(sex == 'female', 0.742, 1)
   f_race <- ifelse(race == 'black' && use_race == TRUE, 1.212, 1)
@@ -476,10 +457,6 @@ egfr_mdrd <- function(sex, race, scr, age, use_race, original_expression) {
 }
 
 egfr_ckd_epi <- function(sex, race, scr, age, use_race) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   a1 <- ifelse(sex == 'female', -0.329, -0.411)
   K <- ifelse(sex == 'female', 0.7, 0.9)
   f_sex <- ifelse(sex == 'female', 1.018, 1)
@@ -488,10 +465,6 @@ egfr_ckd_epi <- function(sex, race, scr, age, use_race) {
 }
 
 egfr_ckd_epi_as_2021 <- function(sex, scr, age) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   a1 <- ifelse(sex == 'female', -0.241, -0.302)
   K <- ifelse(sex == 'female', 0.7, 0.9)
   f_sex <- ifelse(sex == 'female', 1.012, 1)
@@ -499,28 +472,16 @@ egfr_ckd_epi_as_2021 <- function(sex, scr, age) {
 }
 
 egfr_cockcroft_gault_sci <- function(sex, age, scr, weight) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   f_sex <- ifelse(sex == 'female', 0.85, 1)
   0.7 * (f_sex * (140-age) / scr * (weight/72))
 }
 
 egfr_cockcroft_gault <- function(sex, age, scr, weight) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   f_sex <- ifelse(sex == 'female', 0.85, 1)
   f_sex * (140-age) / scr * (weight/72)
 }
 
 egfr_malmo_lund <- function(sex, age, scr) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   scr_cutoff <- ifelse(sex == 'female', 1.696833, 2.0362)
   intercept <- ifelse(sex == 'female', 2.5, 2.56)
   slope <- ifelse(
@@ -534,16 +495,14 @@ egfr_malmo_lund <- function(sex, age, scr) {
 }
 
 egfr_bedside_schwartz <- function(age, height, scr, verbose) {
-  if(age < 1 && verbose) warning("This equation is not meant for patients < 1 years of age.")
+  if(age < 1 && verbose) {
+    warning("This equation is not meant for patients < 1 years of age.")
+  }
   k <- 0.413
   (k * height) / scr
 }
 
 egfr_schwartz <- function(age, preterm, sex, height, scr) {
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
   k <- ifelse(
     age < 1,
     ifelse(preterm, 0.33, 0.45),

--- a/R/calc_egfr.R
+++ b/R/calc_egfr.R
@@ -188,9 +188,9 @@ calc_egfr <- function (
 
   ## Format Sex ----
   sex <- if (is.nil(sex)) '' else tolower(sex)
-  if ("sex" %in% cov_reqs && !all(sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
+  if ("sex" %in% cov_reqs) {
+    sex <- normalize_sex(sex)
+    if (is.null(sex)) return(NULL)
   }
 
   ## Select Weight for eGFR ----

--- a/R/calc_ffm.R
+++ b/R/calc_ffm.R
@@ -29,65 +29,79 @@
 #' calc_ffm(weight = 70, bmi = 25, sex = "male")
 #' calc_ffm(weight = 70, height = 180, age = 40, sex = "female", method = "storset")
 #' @export
-calc_ffm <- function (
+calc_ffm <- function(
   weight = NULL,
   bmi = NULL,
   sex = NULL,
   height = NULL,
   age = NULL,
-  method = c("janmahasatian", "green", "al-sallami", "storset", "bucaloiu", "hume", "james", "garrow_webster"),
-  digits = 1) {
+  method = c(
+    "janmahasatian",
+    "green",
+    "al-sallami",
+    "storset",
+    "bucaloiu",
+    "hume",
+    "james",
+    "garrow_webster"
+  ),
+  digits = 1
+) {
   method <- match.arg(method)
   check_input_lengths(
-    sex = sex,
-    weight = weight,
-    bmi = bmi,
-    height = height,
-    age = age
+    sex = sex, weight = weight, bmi = bmi, height = height, age = age
   )
-  sex <- tolower(sex)
 
-  ffm <- switch(
-    method,
-    "janmahasatian" = ffm_janmahasatian_green(
-      weight = weight,
-      sex = sex,
-      height = height,
-      bmi = bmi
-    ),
-    "green" = ffm_janmahasatian_green(
-      weight = weight,
-      sex = sex,
-      height = height,
-      bmi = bmi
-    ),
-    "al-sallami" = ffm_al_sallami(
-      weight = weight,
-      sex = sex,
-      age = age,
-      height = height,
-      bmi = bmi
-    ),
-    "storset" = ffm_storset( # based on kidney transplant patient
-      weight = weight,
-      sex = sex,
-      height = height,
-      age = age
-    ),
-    "bucaloiu" = ffm_bucaloiu( # morbidly obese females
-      weight = weight,
-      height = height,
-      sex = sex,
-      age = age
-    ),
-    "hume" = ffm_hume(weight = weight, height = height, sex = sex),
-    "james" = ffm_james(weight = weight, height = height, sex = sex),
-    "garrow_webster" = ffm_garrow_webster(
-      weight = weight,
-      height = height,
-      sex = sex
-    )
+  fn <- switch(method,
+    "janmahasatian"  = ffm_janmahasatian_green,
+    "green"          = ffm_janmahasatian_green,
+    "al-sallami"     = ffm_al_sallami,
+    "storset"        = ffm_storset,
+    "bucaloiu"       = ffm_bucaloiu,
+    "hume"           = ffm_hume,
+    "james"          = ffm_james,
+    "garrow_webster" = ffm_garrow_webster
   )
+
+  # Identify required args for selected method --------------------------------
+  fn_formals <- formals(fn)
+  is_required <- sapply(fn_formals, function(.x) identical(.x, alist(a = )[[1]]))
+  required_args <- names(fn_formals)[is_required]
+
+  # If BMI is required but not supplied, compute it if possible ---------------
+  if ("bmi" %in% required_args && is.null(bmi) && !is.null(height) && !is.null(weight)) {
+    bmi <- calc_bmi(height = height, weight = weight)
+  }
+
+  # Check required covariates are present -------------------------------------
+  available <- list(
+    weight = weight, bmi = bmi, sex = sex, height = height, age = age
+  )
+  missing_required <- required_args[
+    sapply(required_args, function(.x) is.null(available[[.x]]))
+  ]
+  if (length(missing_required) > 0) {
+    missing_labels <- ifelse(
+      missing_required == "bmi", "bmi or weight and height", missing_required
+    )
+    stop(sprintf(
+      "Method '%s' requires: %s.",
+      method, paste(missing_labels, collapse = ", ")
+    ))
+  }
+
+  # Central sex validation ----------------------------------------------------
+  sex <- tolower(sex)
+  if (!all(sex %in% c("male", "female"))) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+
+  # fn dispatch (only pass args the inner function accepts) -------------------
+  available <- list(
+    weight = weight, bmi = bmi, sex = sex, height = height, age = age
+  )
+  ffm <- do.call(fn, available[intersect(names(available), formalArgs(fn))])
 
   return(list(
     value = round(ffm, digits),
@@ -96,114 +110,55 @@ calc_ffm <- function (
   ))
 }
 
-ffm_janmahasatian_green <- function(weight, sex, height = NULL, bmi = NULL) {
-  if(is.null(weight) || (is.null(bmi) & is.null(height)) || is.null(sex)) {
-    stop("Equation needs weight, BMI or height, and sex of patient!")
-  }
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
-  if(is.null(bmi)) {
-    bmi <- calc_bmi(height = height, weight = weight)
-  }
-  ffm <- ifelse(
-    sex == "male", 
-    (9.27e03 * weight) / (6.68e03 + 216 * bmi), 
+ffm_janmahasatian_green <- function(weight, sex, bmi) {
+  ifelse(
+    sex == "male",
+    (9.27e03 * weight) / (6.68e03 + 216 * bmi),
     (9.27e03 * weight) / (8.78e03 + 244 * bmi)
   )
-  ffm
 }
 
-ffm_al_sallami <- function(weight, sex, age, height = NULL, bmi = NULL) {
-  if(is.null(weight) || (is.null(bmi) & is.null(height)) || is.null(sex) || is.null(age)) {
-    stop("Equation needs weight, BMI or height, sex, and age of patient!")
-  }
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
-  if(is.null(bmi)) {
-    bmi <- calc_bmi(weight = weight, height = height)
-  }
-  ffm  <- ifelse(
+ffm_al_sallami <- function(weight, sex, age, bmi) {
+  ifelse(
     sex == "female",
-    (1.11 + ((1-1.11)/(1+(age/7.1)^-1.1))) * ((9270 * weight) / (8780 + (244 * bmi))),
-    (0.88 + ((1-0.88)/(1+(age/13.4)^-12.7))) * ((9270 * weight) / (6680 + (216 * bmi)))
+    (1.11 + ((1 - 1.11) / (1 + (age / 7.1)^-1.1)))   * ((9270 * weight) / (8780 + (244 * bmi))),
+    (0.88 + ((1 - 0.88) / (1 + (age / 13.4)^-12.7))) * ((9270 * weight) / (6680 + (216 * bmi)))
   )
-  ffm
 }
 
 ffm_storset <- function(weight, sex, height, age) {
-  if(is.null(weight) || is.null(height) || is.null(sex) || is.null(age)) {
-    stop("Equation needs weight, height, sex, and age of patient!")
-  }
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
-  ffm <- ifelse(
-    sex == "male", 
-    (11.4 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1 - age * 0.0007),
-    (10.2 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1 - age * 0.0007)
-  )
-  ffm
+  coef <- ifelse(sex == "male", 11.4, 10.2)
+  (coef * weight) / (81.3 + weight) * (1 + height * 0.052) * (1 - age * 0.0007)
 }
 
-ffm_bucaloiu <- function(weight, sex, height, age) {
-  if(is.null(weight) || is.null(height) || is.null(sex) || is.null(age)) {
-    stop("Equation needs weight, height, sex, and age of patient!")
-  }
+ffm_bucaloiu <- function(weight, sex, height) {
   bmi <- calc_bmi(weight = weight, height = height)
-  if(any(bmi < 25) || any(!sex == "female")) {
+  if (any(bmi < 25) || any(!sex == "female")) {
     warning("This equation is only meant for obese females.")
   }
-  ffm <- -11.41 + 0.354 * weight + 11.06 * height/100
-  ffm
+  -11.41 + 0.354 * weight + 11.06 * height / 100
 }
 
 ffm_hume <- function(weight, sex, height) {
-  if(is.null(weight) || is.null(height) || is.null(sex)) {
-    stop("Equation needs weight, height, sex of patient!")
-  }
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
-  ffm <- ifelse(
+  ifelse(
     sex == "male",
     0.3281  * weight + 0.33929 * height - 29.5336,
     0.29569 * weight + 0.41813 * height - 43.2933
   )
-  ffm
 }
 
 ffm_james <- function(weight, sex, height) {
-  if(is.null(weight) || is.null(height) || is.null(sex)) {
-    stop("Equation needs weight, height, sex of patient!")
-  }
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
-  ffm <- ifelse(sex == "male",
-    1.1  * weight - 128 * (weight/height)^2,
-    1.07 * weight - 148 * (weight/height)^2
+  ifelse(
+    sex == "male",
+    1.1  * weight - 128 * (weight / height)^2,
+    1.07 * weight - 148 * (weight / height)^2
   )
-  ffm
 }
 
 ffm_garrow_webster <- function(weight, sex, height) {
-  if(is.null(weight) || is.null(height) || is.null(sex)) {
-    stop("Equation needs weight, height, and sex of patient!")
-  }
-  if (any(!sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
-  ffm <- ifelse(sex == "male",
-    0.285 * weight + 12.1  * (height/100)^2,
-    0.287 * weight +  9.74 * (height/100)^2
+  ifelse(
+    sex == "male",
+    0.285 * weight + 12.1  * (height / 100)^2,
+    0.287 * weight +  9.74 * (height / 100)^2
   )
-  ffm
 }

--- a/R/calc_ffm.R
+++ b/R/calc_ffm.R
@@ -47,12 +47,11 @@ calc_ffm <- function(
   ),
   digits = 1
 ) {
-  method <- match.arg(method)
   check_input_lengths(
     sex = sex, weight = weight, bmi = bmi, height = height, age = age
   )
-
-  fn <- switch(method,
+  method <- match.arg(method)
+  method_fn <- switch(method,
     "janmahasatian"  = ffm_janmahasatian_green,
     "green"          = ffm_janmahasatian_green,
     "al-sallami"     = ffm_al_sallami,
@@ -63,45 +62,14 @@ calc_ffm <- function(
     "garrow_webster" = ffm_garrow_webster
   )
 
-  # Identify required args for selected method --------------------------------
-  fn_formals <- formals(fn)
-  is_required <- sapply(fn_formals, function(.x) identical(.x, alist(a = )[[1]]))
-  required_args <- names(fn_formals)[is_required]
-
-  # If BMI is required but not supplied, compute it if possible ---------------
-  if ("bmi" %in% required_args && is.null(bmi) && !is.null(height) && !is.null(weight)) {
-    bmi <- calc_bmi(height = height, weight = weight)
-  }
-
-  # Check required covariates are present -------------------------------------
-  available <- list(
+  inputs <- prepare_method_inputs(method_fn, method,
     weight = weight, bmi = bmi, sex = sex, height = height, age = age
   )
-  missing_required <- required_args[
-    sapply(required_args, function(.x) is.null(available[[.x]]))
-  ]
-  if (length(missing_required) > 0) {
-    missing_labels <- ifelse(
-      missing_required == "bmi", "bmi or weight and height", missing_required
-    )
-    stop(sprintf(
-      "Method '%s' requires: %s.",
-      method, paste(missing_labels, collapse = ", ")
-    ))
-  }
 
-  # Central sex validation ----------------------------------------------------
-  sex <- tolower(sex)
-  if (!all(sex %in% c("male", "female"))) {
-    warning("This method requires sex to be one of 'male' or 'female'.")
-    return(NULL)
-  }
+  inputs$sex <- normalize_sex(inputs$sex)
+  if (is.null(inputs$sex)) return(NULL)
 
-  # fn dispatch (only pass args the inner function accepts) -------------------
-  available <- list(
-    weight = weight, bmi = bmi, sex = sex, height = height, age = age
-  )
-  ffm <- do.call(fn, available[intersect(names(available), formalArgs(fn))])
+  ffm <- do.call(method_fn, inputs[intersect(names(inputs), formalArgs(method_fn))])
 
   return(list(
     value = round(ffm, digits),

--- a/R/calc_ffm.R
+++ b/R/calc_ffm.R
@@ -38,6 +38,13 @@ calc_ffm <- function (
   method = c("janmahasatian", "green", "al-sallami", "storset", "bucaloiu", "hume", "james", "garrow_webster"),
   digits = 1) {
   method <- match.arg(method)
+  check_input_lengths(
+    sex = sex,
+    weight = weight,
+    bmi = bmi,
+    height = height,
+    age = age
+  )
   sex <- tolower(sex)
 
   ffm <- switch(
@@ -93,18 +100,18 @@ ffm_janmahasatian_green <- function(weight, sex, height = NULL, bmi = NULL) {
   if(is.null(weight) || (is.null(bmi) & is.null(height)) || is.null(sex)) {
     stop("Equation needs weight, BMI or height, and sex of patient!")
   }
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
   if(is.null(bmi)) {
     bmi <- calc_bmi(height = height, weight = weight)
   }
-  if(sex == "male") {
-    ffm <- (9.27e03 * weight) / ((6.68e03) + 216 * bmi)
-  } else {
-    ffm <- (9.27e03 * weight) / ((8.78e03) + 244 * bmi)
-  }
+  ffm <- ifelse(
+    sex == "male", 
+    (9.27e03 * weight) / (6.68e03 + 216 * bmi), 
+    (9.27e03 * weight) / (8.78e03 + 244 * bmi)
+  )
   ffm
 }
 
@@ -112,18 +119,18 @@ ffm_al_sallami <- function(weight, sex, age, height = NULL, bmi = NULL) {
   if(is.null(weight) || (is.null(bmi) & is.null(height)) || is.null(sex) || is.null(age)) {
     stop("Equation needs weight, BMI or height, sex, and age of patient!")
   }
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
   if(is.null(bmi)) {
     bmi <- calc_bmi(weight = weight, height = height)
   }
-  if(sex == "female") {
-    ffm <- (1.11 + ((1-1.11)/(1+(age/7.1)^-1.1))) * ((9270 * weight)/(8780 + (244 * bmi)))
-  } else {
-    ffm <- (0.88 + ((1-0.88)/(1+(age/13.4)^-12.7))) * ((9270 * weight)/(6680 + (216 * bmi)))
-  }
+  ffm  <- ifelse(
+    sex == "female",
+    (1.11 + ((1-1.11)/(1+(age/7.1)^-1.1))) * ((9270 * weight) / (8780 + (244 * bmi))),
+    (0.88 + ((1-0.88)/(1+(age/13.4)^-12.7))) * ((9270 * weight) / (6680 + (216 * bmi)))
+  )
   ffm
 }
 
@@ -131,15 +138,15 @@ ffm_storset <- function(weight, sex, height, age) {
   if(is.null(weight) || is.null(height) || is.null(sex) || is.null(age)) {
     stop("Equation needs weight, height, sex, and age of patient!")
   }
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
-  if(sex == "male") {
-    ffm <- (11.4 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1-age*0.0007)
-  } else {
-    ffm <- (10.2 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1-age*0.0007)
-  }
+  ffm <- ifelse(
+    sex == "male", 
+    (11.4 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1 - age * 0.0007),
+    (10.2 * weight) / (81.3 + weight) * (1 + height * 0.052) * (1 - age * 0.0007)
+  )
   ffm
 }
 
@@ -148,7 +155,7 @@ ffm_bucaloiu <- function(weight, sex, height, age) {
     stop("Equation needs weight, height, sex, and age of patient!")
   }
   bmi <- calc_bmi(weight = weight, height = height)
-  if(any(bmi < 25) || !sex == "female") {
+  if(any(bmi < 25) || any(!sex == "female")) {
     warning("This equation is only meant for obese females.")
   }
   ffm <- -11.41 + 0.354 * weight + 11.06 * height/100
@@ -159,15 +166,15 @@ ffm_hume <- function(weight, sex, height) {
   if(is.null(weight) || is.null(height) || is.null(sex)) {
     stop("Equation needs weight, height, sex of patient!")
   }
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
-  if(sex == "male") {
-    ffm <- 0.3281 * weight + 0.33929 * height - 29.5336
-  } else {
-    ffm <- 0.29569 * weight + 0.41813 * height - 43.2933
-  }
+  ffm <- ifelse(
+    sex == "male",
+    0.3281  * weight + 0.33929 * height - 29.5336,
+    0.29569 * weight + 0.41813 * height - 43.2933
+  )
   ffm
 }
 
@@ -175,15 +182,14 @@ ffm_james <- function(weight, sex, height) {
   if(is.null(weight) || is.null(height) || is.null(sex)) {
     stop("Equation needs weight, height, sex of patient!")
   }
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
-  if(sex == "male") {
-    ffm <- 1.1 * weight - 128*(weight/height)^2
-  } else {
-    ffm <- 1.07 * weight - 148*(weight/height)^2
-  }
+  ffm <- ifelse(sex == "male",
+    1.1  * weight - 128 * (weight/height)^2,
+    1.07 * weight - 148 * (weight/height)^2
+  )
   ffm
 }
 
@@ -191,14 +197,13 @@ ffm_garrow_webster <- function(weight, sex, height) {
   if(is.null(weight) || is.null(height) || is.null(sex)) {
     stop("Equation needs weight, height, and sex of patient!")
   }
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("This method requires sex to be one of 'male' or 'female'.")
     return(NULL)
   }
-  if(sex == "male") {
-    ffm <- 0.285 * weight + 12.1*(height/100)^2
-  } else {
-    ffm <- 0.287 * weight + 9.74*(height/100)^2
-  }
+  ffm <- ifelse(sex == "male",
+    0.285 * weight + 12.1  * (height/100)^2,
+    0.287 * weight +  9.74 * (height/100)^2
+  )
   ffm
 }

--- a/R/calc_ibw.R
+++ b/R/calc_ibw.R
@@ -52,33 +52,27 @@ calc_ibw <- function (
   if(is.null(age)) {
     stop("Age not specified!")
   }
-  stopifnot(
-    length(age) == 1,
-    length(height) <= 1, # these are not always
-    length(weight) <= 1, # required, so may be
-    length(sex) <= 1     # NULL or length 1
-  )
+  check_input_lengths(age = age, weight = weight, height = height, sex = sex)
 
-  ## babies
-  if (age < 1) {
+  if (any(age < 1)) {
     if (is.null(weight)) {
       stop("Actual body weight is used as IBW for children < 1yr. Please supply a weight value.")
     }
     message("Note: using actual body weight as IBW for children < 1yr.")
-    return(weight)
   }
 
-  if (age >= 1 & age < 18) {
-    ibw <- switch(
-      method_children,
-      "standard" = ibw_standard(age = age, height = height, sex = sex)
+  ibw_children <- switch(method_children, "standard" = ibw_standard)
+  ibw_adults <- switch(method_adults, "devine" = ibw_devine)
+
+  ibw <- ifelse(
+    age < 1,
+    weight,
+    ifelse(
+      age < 18,
+      suppressWarnings(ibw_children(age = age, height = height, sex = sex)),
+      suppressWarnings(ibw_adults(age = age, height = height, sex = sex))
     )
-  } else {
-    ibw <- switch(
-      method_adults,
-      "devine" = ibw_devine(age = age, height = height, sex = sex)
-    )
-  }
+  )
 
   return(ibw)
 }
@@ -87,53 +81,50 @@ calc_ibw <- function (
 #'
 #' @rdname calc_ibw
 ibw_standard <- function(age, height = NULL, sex = NULL) {
-  if (is.null(age) || age >= 18 || age < 1) {
+  if (is.null(age) || any(age >= 18) || any(age < 1)) {
     warning("Age should be >=1 and <18 for the `standard` method.")
   }
-  if (is.null(height) || is.na(height)) {
+  if (is.null(height) || any(is.na(height))) {
     stop("Height is required to calculate IBW")
   }
   height_in <- cm2inch(height)
-  if (height_in < 5 * 12) {
-    return((height^2 * 1.65) / 1000)
+  # Sex is only required when height >= 5ft
+  if (any(height_in >= 5 * 12)) {
+    if (is.null(sex) || any(is.na(sex))) {
+      stop("Sex is required to calculate IBW when height is >= 5 feet")
+    }
+    if (any(!sex %in% c("male", "female"))) {
+      warning("The `standard` method for calculating IBW requires sex to be 'male' or 'female' for children 5 feet tall or taller.")
+      return(NULL)
+    }
   }
-  if (is.null(sex) || is.na(sex)) {
-    # Sex is only required if height >= 5ft, so this must come after the lines
-    # above
-    stop("Sex is required to calculate IBW when height is >= 5 feet")
-  }
-  if (!sex %in% c("male", "female")) {
-    warning("The `standard` method for calculating IBW requires sex to be 'male' or 'female' for children 5 feet tall or taller.")
-    return(NULL)
-  }
-  base_value <- switch(
-    sex,
-    "male" = 39,
-    "female" = 42.2
-  )
+  base_value <- if (!is.null(sex)) ifelse(sex == "male", 39, 42.2) else NA_real_
   height_inches_over_5_feet <- height_in - (5 * 12)
-  base_value + (2.27 * height_inches_over_5_feet)
+  ifelse(
+    height_in < 5 * 12,
+    (height^2 * 1.65) / 1000,
+    base_value + (2.27 * height_inches_over_5_feet)
+  )
 }
 
 #' Calculate IBW using "devine" equation
 #'
 #' @rdname calc_ibw
 ibw_devine <- function(age, height = NULL, sex = NULL) {
-  if (age < 18) {
+  if (is.null(age)) {
+    stop("Age is required to calculate IBW")
+  }
+  if (any(age < 18)) {
     warning("Age should be >18 for the `devine` method.")
   }
-  if (is.null(height) || is.na(height) || is.null(sex) || is.na(sex)) {
+  if (is.null(height) || any(is.na(height)) || is.null(sex) || any(is.na(sex))) {
     stop("Height and sex are required to calculate IBW")
   }
-  if (!sex %in% c("male", "female")) {
+  if (any(!sex %in% c("male", "female"))) {
     warning("The `devine` method for calculating IBW requires sex to be 'male' or 'female'.")
     return(NULL)
   }
-  base_value <- switch(
-    sex,
-    "male" = 50,
-    "female" = 45.5
-  )
+  base_value <- ifelse(sex == "male", 50, 45.5)
   height_in <- cm2inch(height)
   height_inches_over_5_feet <- height_in - (5 * 12)
   base_value + (2.3 * height_inches_over_5_feet)

--- a/R/calc_lbw.R
+++ b/R/calc_lbw.R
@@ -24,64 +24,66 @@
 #' calc_lbw(weight = 80, height = 170, sex = "male")
 #' calc_lbw(weight = 80, height = 170, sex = "male", method = "james")
 #' @export
-calc_lbw <- function (
+calc_lbw <- function(
   weight = NULL,
   bmi = NULL,
   sex = NULL,
   height = NULL,
-  method = "green",
-  digits = 1) {
-  methods <- c("green", "boer", "james", "hume")
-  if(! method %in% methods) {
-    stop(paste0("Unknown estimation method, please choose from: ", paste(methods, collapse=" ")))
-  }
-  if(is.null(sex) || !all(sex %in% c("male", "female"))) {
-    stop("Sex needs to be either male or female!")
-  }
+  method = c("green", "boer", "james", "hume"),
+  digits = 1
+) {
   check_input_lengths(sex = sex, weight = weight, height = height, bmi = bmi)
-  if(method %in% c("boer", "james", "hume")) {
-    if(is.null(weight) || is.null(height) || is.null(sex)) {
-      stop("Equation needs weight, BMI or height, and sex of patient!")
-    } else {
-      if(method == "boer") {
-        lbm <- ifelse(
-          sex == "male",
-          0.407 * weight + 0.267 * height - 19.2,
-          0.252 * weight + 0.473 * height - 48.3
-        )
-      }
-      if(method == "hume") {
-        lbm <- ifelse(
-          sex == "male",
-          0.3281  * weight + 0.33929 * height - 29.5336,
-          0.29569 * weight + 0.41813 * height - 43.2933
-        )
-      }
-      if(method == "james") {
-        lbm <- ifelse(
-          sex == "male",
-          1.1  * weight - 128 * (weight/height)^2,
-          1.07 * weight - 148 * (weight/height)^2
-        )
-      }
-    }
-  }
-  if(method == "green") {
-    if(is.null(weight) || (is.null(bmi) & is.null(height)) || is.null(sex)) {
-      stop("Equation needs weight, BMI or height, and sex of patient!")
-    } else {
-      if(is.null(bmi)) {
-        bmi <- calc_bmi(height = height, weight = weight)
-      }
-      lbm <- ifelse(
-        sex == "male",
-        (1.1  * weight) - 0.0128 * bmi * weight,
-        (1.07 * weight) - 0.0148 * bmi * weight
-      )
-    }
-  }
+  method <- match.arg(method)
+  method_fn <- switch(method,
+    "green" = lbw_green,
+    "boer"  = lbw_boer,
+    "james" = lbw_james,
+    "hume"  = lbw_hume
+  )
+
+  inputs <- prepare_method_inputs(method_fn, method,
+    weight = weight, bmi = bmi, sex = sex, height = height
+  )
+
+  inputs$sex <- normalize_sex(inputs$sex)
+  if (is.null(inputs$sex)) return(NULL)
+
+  lbw <- do.call(method_fn, inputs[intersect(names(inputs), formalArgs(method_fn))])
+
   return(list(
-    value = round(lbm,1),
+    value = round(lbw, digits),
     unit = "kg"
   ))
+}
+
+lbw_green <- function(weight, sex, bmi) {
+  ifelse(
+    sex == "male",
+    (1.1  * weight) - 0.0128 * bmi * weight,
+    (1.07 * weight) - 0.0148 * bmi * weight
+  )
+}
+
+lbw_boer <- function(weight, sex, height) {
+  ifelse(
+    sex == "male",
+    0.407 * weight + 0.267 * height - 19.2,
+    0.252 * weight + 0.473 * height - 48.3
+  )
+}
+
+lbw_james <- function(weight, sex, height) {
+  ifelse(
+    sex == "male",
+    1.1  * weight - 128 * (weight / height)^2,
+    1.07 * weight - 148 * (weight / height)^2
+  )
+}
+
+lbw_hume <- function(weight, sex, height) {
+  ifelse(
+    sex == "male",
+    0.3281  * weight + 0.33929 * height - 29.5336,
+    0.29569 * weight + 0.41813 * height - 43.2933
+  )
 }

--- a/R/calc_lbw.R
+++ b/R/calc_lbw.R
@@ -35,33 +35,34 @@ calc_lbw <- function (
   if(! method %in% methods) {
     stop(paste0("Unknown estimation method, please choose from: ", paste(methods, collapse=" ")))
   }
-  if(is.null(sex) || !(sex %in% c("male", "female"))) {
+  if(is.null(sex) || !all(sex %in% c("male", "female"))) {
     stop("Sex needs to be either male or female!")
   }
+  check_input_lengths(sex = sex, weight = weight, height = height, bmi = bmi)
   if(method %in% c("boer", "james", "hume")) {
     if(is.null(weight) || is.null(height) || is.null(sex)) {
       stop("Equation needs weight, BMI or height, and sex of patient!")
     } else {
       if(method == "boer") {
-        if(sex == "male") {
-          lbm <-  0.407 * weight + 0.267 * height - 19.2
-        } else {
-          lbm <-  0.252 * weight + 0.473 * height - 48.3
-        }
+        lbm <- ifelse(
+          sex == "male",
+          0.407 * weight + 0.267 * height - 19.2,
+          0.252 * weight + 0.473 * height - 48.3
+        )
       }
       if(method == "hume") {
-        if(sex == "male") {
-          lbm <-  0.3281 * weight + 0.33929 * height - 29.5336
-        } else {
-          lbm <-  0.29569 * weight + 0.41813 * height - 43.2933
-        }
+        lbm <- ifelse(
+          sex == "male",
+          0.3281  * weight + 0.33929 * height - 29.5336,
+          0.29569 * weight + 0.41813 * height - 43.2933
+        )
       }
       if(method == "james") {
-        if(sex == "male") {
-          lbm <-  1.1 * weight - 128 * (weight/height)^2
-        } else {
-          lbm <-  1.07 * weight - 148 * (weight/height)^2
-        }
+        lbm <- ifelse(
+          sex == "male",
+          1.1  * weight - 128 * (weight/height)^2,
+          1.07 * weight - 148 * (weight/height)^2
+        )
       }
     }
   }
@@ -72,11 +73,11 @@ calc_lbw <- function (
       if(is.null(bmi)) {
         bmi <- calc_bmi(height = height, weight = weight)
       }
-      if(sex == "male") {
-        lbm <- (1.1 * weight) - 0.0128 * bmi * weight
-      } else {
-        lbm <- (1.07 * weight) - 0.0148 * bmi * weight
-      }
+      lbm <- ifelse(
+        sex == "male",
+        (1.1  * weight) - 0.0128 * bmi * weight,
+        (1.07 * weight) - 0.0148 * bmi * weight
+      )
     }
   }
   return(list(

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,6 +13,65 @@ check_input_lengths <- function(...) {
   }
 }
 
+#' Resolve and validate inputs for a method-dispatched function
+#'
+#' Identifies required arguments for `fn`, auto-computes `bmi` from `height`
+#' and `weight` when needed, then stops with an informative message if any
+#' required argument is still missing.
+#'
+#' @param fn The inner method function to be called.
+#' @param method Character string naming the method (used in error messages).
+#' @param ... Named input arguments (e.g. weight, bmi, sex, height, age).
+#' @return A named list of the supplied inputs, with `bmi` computed if needed.
+#' @keywords internal
+prepare_method_inputs <- function(fn, method, ...) {
+  inputs <- list(...)
+
+  # Detect required (no-default) arguments:
+  fn_formals <- formals(fn)
+  required <- names(fn_formals)[
+    sapply(fn_formals, function(.x) identical(.x, alist(a = )[[1]]))
+  ]
+
+  # Auto-compute bmi from height + weight if bmi is required but not supplied:
+  if ("bmi" %in% required && is.null(inputs$bmi) &&
+      !is.null(inputs$height) && !is.null(inputs$weight)) {
+    inputs$bmi <- calc_bmi(height = inputs$height, weight = inputs$weight)
+  }
+
+  # Check all required args are present:
+  missing_args <- required[sapply(required, function(.x) is.null(inputs[[.x]]))]
+  if (length(missing_args) > 0) {
+    missing_labels <- ifelse(
+      missing_args == "bmi", "bmi or weight and height", missing_args
+    )
+    stop(sprintf(
+      "Method '%s' requires: %s.",
+      method, paste(missing_labels, collapse = ", ")
+    ))
+  }
+
+  inputs
+}
+
+#' Validate and normalize a sex argument
+#'
+#' Lowercases `sex` and checks every element is `"male"` or `"female"`. If
+#' not, issues a warning and returns `NULL` so the calling function can
+#' short-circuit with `return(NULL)`.
+#'
+#' @param sex Character vector.
+#' @return Lowercased `sex`, or `NULL` (invisibly) after a warning.
+#' @keywords internal
+normalize_sex <- function(sex) {
+  sex <- tolower(sex)
+  if (length(sex) == 0 || !all(sex %in% c("male", "female"))) {
+    warning("This method requires sex to be one of 'male' or 'female'.")
+    return(NULL)
+  }
+  sex
+}
+
 #' Check if values in vector are empty
 #'
 #' @param x vector

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,18 @@
+#' Check for inconsistent vector lengths among inputs
+#'
+#' @param ... named arguments to check
+#' @keywords internal
+check_input_lengths <- function(...) {
+  input_lengths <- lengths(Filter(
+    function(x) !is.null(x) && length(x) > 1,
+    list(...)
+  ))
+  if (length(unique(input_lengths)) > 1) {
+    sizes <- paste(sprintf("`%s` (size %d)", names(input_lengths), input_lengths), collapse = ", ")
+    stop(sprintf("Vector inputs must all be the same length: %s.", sizes))
+  }
+}
+
 #' Check if values in vector are empty
 #'
 #' @param x vector

--- a/tests/testthat/test_calc_dosing_weight.R
+++ b/tests/testthat/test_calc_dosing_weight.R
@@ -39,3 +39,33 @@ test_that("Dosing weight is calculated", {
     50
   )
 })
+
+test_that("Dosing weight is calculated (vectorized)", {
+  expect_equal(
+    round(
+      calc_dosing_weight(
+        weight = c(160, 60, 50),
+        height = 160,
+        age= 50,
+        sex = "female",
+        verbose = FALSE
+      )$value,
+      1
+    ),
+    c(95.4, 52.4, 50)
+  )
+})
+
+test_that("vectorization over different sex values works", {
+  male_val <- calc_dosing_weight(
+    weight = 80, height = 170, age = 40, sex = "male",   verbose = FALSE
+  )$value
+  female_val <- calc_dosing_weight(
+    weight = 80, height = 170, age = 40, sex = "female", verbose = FALSE
+  )$value
+  vec_val <- calc_dosing_weight(
+    weight = c(80, 80), height = c(170, 170), age = c(40, 40),
+    sex = c("male", "female"), verbose = FALSE
+  )$value
+  expect_equal(vec_val, c(male_val, female_val))
+})

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -1,6 +1,7 @@
 test_that("calculate egfr works: cockroft_gault", {
   expect_error(
-    suppressMessages(calc_egfr(scr = .5, weight = 4.5, method = "cockcroft_gault"))
+    suppressMessages(calc_egfr(scr = .5, weight = 4.5, method = "cockcroft_gault")),
+    "Sorry, missing covariates:"
   )
 
   expect_equal(
@@ -218,7 +219,8 @@ test_that("calculate egfr works: malmo lund", {
       method = "malmo_lund_revised",
       relative = FALSE,
       verbose = FALSE
-    )
+    ),
+    "Sorry, missing covariates:"
   )
 
   expect_equal(
@@ -258,7 +260,8 @@ test_that("calculate egfr works: schwartz", {
       weight = 4.5,
       method = "schwartz",
       verbose = FALSE
-    )
+    ),
+    "Sorry, missing covariates:"
   )
 
   expect_equal(
@@ -547,7 +550,7 @@ test_that("egfr cap applied and info added", {
 })
 
 test_that("calc_egfr does not error for patients < 1yr when calculating ibw", {
-  expect_error(
+  expect_no_error(
     suppressMessages(calc_egfr(
       age = 0.03,
       sex = "female",
@@ -555,10 +558,9 @@ test_that("calc_egfr does not error for patients < 1yr when calculating ibw", {
       height = 30,
       scr = 0.5,
       method = "cockcroft_gault_adjusted"
-    )),
-    NA
+    ))
   )
-  expect_error(
+  expect_no_error(
     suppressMessages(calc_egfr(
       age = 0.03,
       sex = "female",
@@ -566,8 +568,7 @@ test_that("calc_egfr does not error for patients < 1yr when calculating ibw", {
       height = 30,
       scr = 0.5,
       method = "cockcroft_gault_ideal"
-    )),
-    NA
+    ))
   )
 })
 
@@ -677,17 +678,39 @@ test_that("eGFR for mdrd_ignore_race and mdrd_original_ignore_race", {
 })
 
 test_that("calc_egfr warns and returns NULL if sex isn't supported", {
-  expect_warning(
-    res <- calc_egfr(
-      age = 40,
-      sex = "unknown",
-      weight = 80,
-      scr = 1,
-      method = "cockcroft_gault",
-      verbose = FALSE
-    )
+  methods <- c(
+    "cockcroft_gault",
+    "cockcroft_gault_sci",
+    "cockcroft_gault_ideal",
+    "cockcroft_gault_adjusted",
+    "cockcroft_gault_adaptive",
+    "wright",
+    "jelliffe",
+    "jelliffe_unstable",
+    "mdrd_ignore_race",
+    "mdrd_original_ignore_race",
+    "ckd_epi_ignore_race",
+    "ckd_epi_as_2021",
+    "malmo_lund_revised",
+    "schwartz"
   )
-  expect_null(res$value)
+  
+  for (m in methods) {
+    expect_warning(
+      res <- calc_egfr(
+        age = 40,
+        sex = "unknown",
+        weight = 80,
+        height = 170,
+        scr = 1,
+        method = m,
+        verbose = FALSE
+      ),
+      "This method requires sex to be one of 'male' or 'female'.",
+      label = paste("method:", m)
+    )
+    expect_null(res$value, label = paste("method:", m))
+  }
 })
 
 test_that("calc_egfr converts scr appropriately", {

--- a/tests/testthat/test_calc_egfr.R
+++ b/tests/testthat/test_calc_egfr.R
@@ -782,3 +782,54 @@ test_that("missing scr_units handled well", {
   expect_equal(res2, expect_res)
   expect_equal(res3, expect_res)
 })
+
+test_that("vectorization over different sex values works for all methods", {
+  methods <- c(
+    "cockcroft_gault",
+    "cockcroft_gault_sci",
+    "cockcroft_gault_ideal",
+    "cockcroft_gault_adjusted",
+    "cockcroft_gault_adaptive",
+    "wright",
+    "jelliffe",
+    "jelliffe_unstable",
+    "mdrd_ignore_race",
+    "mdrd_original_ignore_race",
+    "ckd_epi_ignore_race",
+    "ckd_epi_as_2021",
+    "malmo_lund_revised",
+    "schwartz"
+  )
+
+  for (m in methods) {
+    male_val <- calc_egfr(
+      method = m, sex = "male", age = 30, scr = 0.5,
+      weight = 80, height = 170, bsa = 1.9, unit_out = "ml/min", verbose = FALSE
+    )$value
+    female_val <- calc_egfr(
+      method = m, sex = "female", age = 30, scr = 0.5,
+      weight = 80, height = 170, bsa = 1.9, unit_out = "ml/min", verbose = FALSE
+    )$value
+    vec_val <- calc_egfr(
+      method = m, sex = c("male", "female"), age = c(30, 30), scr = c(0.5, 0.5),
+      weight = c(80, 80), height = c(170, 170), bsa = c(1.9, 1.9),
+      unit_out = "ml/min", verbose = FALSE
+    )$value
+    expect_equal(vec_val, c(male_val, female_val), label = paste("method:", m))
+  }
+})
+
+test_that("calc_egfr() errors on mismatched vector lengths", {
+  expect_error(
+    calc_egfr(
+      method = "ckd_epi_as_2021",
+      sex = c("male", "female"), # length 2
+      age = c(30, 40, 50), # length 3
+      scr = 0.5,
+      weight = 80,
+      height = 170,
+      verbose = FALSE
+    ),
+    "Vector inputs must all be the same length: `sex` \\(size 2\\), `age` \\(size 3\\)\\."
+  )
+})

--- a/tests/testthat/test_calc_ffm.R
+++ b/tests/testthat/test_calc_ffm.R
@@ -1,33 +1,13 @@
 test_that("FFM calculation works", {
+  expect_equal(round(calc_ffm(weight = 80, bmi = 20, sex = "male")$value), 67)
+  expect_equal(round(calc_ffm(weight = 80, bmi = 30, sex = "male")$value), 56)
+  expect_equal(round(calc_ffm(weight = 80, bmi = 30, sex = "female")$value), 46)
   expect_equal(
-    round(calc_ffm (
-      weight = 80,
-      bmi = 20,
-      sex = "male"
-    )$value),
-    67
-  )
-  expect_equal(
-    round(calc_ffm (
-      weight = 80,
-      bmi = 30,
-      sex = "male"
-    )$value),
-    56
-  )
-  expect_equal(
-    round(calc_ffm (
-      weight = 80,
-      bmi = 30,
-      sex = "female"
-    )$value),
-    46
-  )
-  expect_equal(
-    round(calc_ffm (
-      weight = 60, height = 140, age = 12,
-      sex = "female", method = "al-sallami"
-    )$value),
+    round(
+      calc_ffm(
+        weight = 60, height = 140, age = 12, sex = "female", method = "al-sallami"
+      )$value
+    ),
     36
   )
 })
@@ -60,6 +40,31 @@ test_that("vectorization over different sex values works for all methods", {
   }
 })
 
+test_that("vectorization propagates NAs in output", {
+  # bmi:
+  res1 <- calc_ffm(weight = c(80, 80), bmi = c(NA, 20), sex = c("male", "female"))$value
+  expect_true(is.na(res1[1]))
+  expect_false(is.na(res1[2]))
+  # height:
+  res2 <- calc_ffm(weight = c(80, 80), height = c(170, NA), sex = c("male", "female"))$value
+  expect_false(is.na(res2[1]))
+  expect_true(is.na(res2[2]))
+  # weight:
+  res3 <- calc_ffm(weight = c(80, NA), bmi = c(20, 20), sex = c("male", "female"))$value
+  expect_false(is.na(res3[1]))
+  expect_true(is.na(res3[2]))
+  # age:
+  res4 <- calc_ffm(
+    weight = c(80, 80),
+    height = c(170, 170),
+    age = c(30, NA),
+    sex = c("male", "female"),
+    method = "al-sallami"
+  )$value
+  expect_false(is.na(res4[1]))
+  expect_true(is.na(res4[2]))
+})
+
 test_that("calc_ffm() errors on mismatched vector lengths", {
   expect_error(
     calc_ffm(
@@ -71,91 +76,153 @@ test_that("calc_ffm() errors on mismatched vector lengths", {
   )
 })
 
-test_that("ffm functions error if missing info", {
+test_that("calc_ffm() errors if missing required covariates", {
   expect_error(
-    ffm_janmahasatian_green(weight = 80, sex = "male")
+    calc_ffm(weight = 80, sex = "male"),
+    "Method 'janmahasatian' requires: bmi or weight and height."
   )
   expect_error(
-    ffm_al_sallami(weight = 80, sex = "male", height = 180, age = NULL)
+    calc_ffm(weight = 80, sex = "male", height = 180, method = "al-sallami"),
+    "Method 'al-sallami' requires: age."
   )
-  expect_error(ffm_storset(weight = NULL, sex = "female", height = 180))
-  expect_error(ffm_bucaloiu(weight = NULL, height = NULL, sex = NULL))
-  expect_error(ffm_hume(weight = 80, sex = NULL, height = 150))
-  expect_error(ffm_james(weight = NULL, sex = NULL, height = NULL))
-  expect_error(ffm_garrow_webster(weight = 90, sex = "female", height = NULL))
+  expect_error(
+    calc_ffm(sex = "female", height = 180, method = "storset"),
+    "Method 'storset' requires: weight"
+  )
+  expect_error(
+    calc_ffm(method = "bucaloiu"),
+    "Method 'bucaloiu' requires: weight, sex, height."
+  )
+  expect_error(
+    calc_ffm(weight = 80, height = 150, method = "hume"),
+    "Method 'hume' requires: sex."
+  )
+  expect_error(
+    calc_ffm(method = "james"),
+    "Method 'james' requires: weight, sex, height."
+  )
+  expect_error(
+    calc_ffm(weight = 90, sex = "female", method = "garrow_webster"),
+    "Method 'garrow_webster' requires: height."
+  )
 })
 
-test_that("ffm functions warn and return NULL if sex not supported", {
-  expect_warning(
-    expect_null(
-      ffm_janmahasatian_green(weight = 80, sex = "unknown", height = 150)
-    )
+test_that("calc_ffm() warns and returns NULL if sex value not supported", {
+  methods_with_sex <- c(
+    "janmahasatian",
+    "al-sallami",
+    "storset",
+    "hume",
+    "james",
+    "garrow_webster"
   )
-  expect_warning(
-    expect_null(
-      ffm_al_sallami(weight = 80, sex = "unknown", height = 180, age = 20)
+  for (m in methods_with_sex) {
+    expect_warning(
+      expect_null(
+        calc_ffm(
+          weight = 80,
+          sex = "unknown", # Unsupported value
+          height = 150,
+          bmi = 20,
+          age = 20,
+          method = m
+        )
+      ),
+      label = paste("method:", m)
     )
-  )
-  expect_warning(
-    expect_null(
-      ffm_storset(weight = 80, sex = "unknown", height = 180, age = 20)
-    )
-  )
-  expect_warning(
-    expect_null(
-      ffm_hume(weight = 80, sex = "unknown", height = 150)
-    )
-  )
-  expect_warning(
-    expect_null(
-      ffm_james(weight = 80, sex = "unknown", height = 150)
-    )
-  )
-  expect_warning(
-    expect_null(
-      ffm_garrow_webster(weight = 90, sex = "unknown", height = 150)
-    )
-  )
+  }
 })
 
 test_that("ffm_bucaloiu warns if used for other than obese females", {
   expect_warning(
-    res1 <- ffm_bucaloiu(weight = 50, sex = "female", height = 150, age = 20)
+    res1 <- calc_ffm(
+      weight = 50, sex = "female", height = 150, age = 20, method = "bucaloiu"
+    )$value,
+    "This equation is only meant for obese females."
   )
+  expect_equal(res1, 22.90)
+  
+  # Invalid sex is caught centrally before reaching ffm_bucaloiu():
   expect_warning(
-    res2 <- ffm_bucaloiu(weight = 100, sex = "unknown", height = 150, age = 20)
+    res2 <- calc_ffm(
+      weight = 100, sex = "unknown", height = 150, age = 20, method = "bucaloiu"
+    ),
+    "This method requires sex to be one of 'male' or 'female'."
   )
-  expect_equal(res1, 22.88)
-  expect_equal(res2, 40.58)
+  expect_null(res2)
 })
 
 test_that("ffm equations give expected values", {
   expect_equal(
-    ffm_janmahasatian_green(weight = 80, sex = "male", height = 150),
+    calc_ffm(
+      weight = 80,
+      sex = "male",
+      height = 150,
+      digits = 10
+    )$value,
     51.643454
   )
   expect_equal(
-    ffm_al_sallami(weight = 80, sex = "male", height = 150, age = 20),
+    calc_ffm(
+      weight = 80,
+      sex = "male",
+      height = 150,
+      age = 20,
+      method = "al-sallami",
+      digits = 10
+    )$value,
     51.605376
   )
   expect_equal(
-    ffm_storset(weight = 80, sex = "male", height = 180, age = 20),
+    calc_ffm(
+      weight = 80,
+      sex = "male",
+      height = 180,
+      age = 20,
+      method = "storset",
+      digits = 10
+    )$value,
     57.756004
   )
   expect_equal(
-    ffm_bucaloiu(weight = 80, sex = "female", height = 150, age = 20),
+    suppressWarnings(calc_ffm(
+      weight = 80,
+      sex = "female",
+      height = 150,
+      age = 20,
+      method = "bucaloiu",
+      digits = 10
+    ))$value, 
     33.5
   )
   expect_equal(
-    ffm_hume(weight = 80, sex = "female", height = 150),
+    calc_ffm(
+      weight = 80,
+      sex = "female",
+      height = 150,
+      method = "hume",
+      digits = 10
+    )$value,
     43.0814
   )
   expect_equal(
-    ffm_james(weight = 80, sex = "female", height = 150),
+    calc_ffm(
+      weight = 80,
+      sex = "female",
+      height = 150,
+      method = "james",
+      digits = 10
+    )$value,
     43.502222
   )
   expect_equal(
-    ffm_garrow_webster(weight = 80, sex = "female", height = 150),
+    calc_ffm(
+      weight = 80,
+      sex = "female",
+      height = 150,
+      method = "garrow_webster",
+      digits = 10
+    )$value,
     44.875
   )
 })

--- a/tests/testthat/test_calc_ffm.R
+++ b/tests/testthat/test_calc_ffm.R
@@ -32,6 +32,45 @@ test_that("FFM calculation works", {
   )
 })
 
+test_that("vectorization over different sex values works for all methods", {
+  methods <- c(
+    "janmahasatian",
+    "green",
+    "al-sallami",
+    "storset",
+    "bucaloiu",
+    "hume",
+    "james",
+    "garrow_webster"
+  )
+
+  # suppressWarnings is for "bucaloiu" method, which is only meant for obese females.
+  for (m in methods) {
+    male_val <- suppressWarnings(calc_ffm(
+      method = m, sex = "male", weight = 80, bmi = 20, height = 170, age = 30
+    )$value)
+    female_val <- suppressWarnings(calc_ffm(
+      method = m, sex = "female", weight = 80, bmi = 20, height = 170, age = 30
+    )$value)
+    vec_val <- suppressWarnings(calc_ffm(
+      method = m, sex = c("male", "female"), weight = c(80, 80),
+      bmi = c(20, 20), height = c(170, 170), age = c(30, 30)
+    )$value)
+    expect_equal(vec_val, c(male_val, female_val), label = paste("method:", m))
+  }
+})
+
+test_that("calc_ffm() errors on mismatched vector lengths", {
+  expect_error(
+    calc_ffm(
+      weight = c(80, 80), # length 2
+      bmi = c(20, 20, 20), # length 3
+      sex = "male"
+    ),
+    "Vector inputs must all be the same length: `weight` \\(size 2\\), `bmi` \\(size 3\\)\\."
+  )
+})
+
 test_that("ffm functions error if missing info", {
   expect_error(
     ffm_janmahasatian_green(weight = 80, sex = "male")

--- a/tests/testthat/test_calc_ibw.R
+++ b/tests/testthat/test_calc_ibw.R
@@ -17,9 +17,24 @@ test_that("calc_ibw() errors if method doesn't match allowed", {
   expect_error(calc_ibw(method_adults = "foo"))
 })
 
-test_that("calc_ibw errors if passed a vector", {
+test_that("vectorization over different sex values works", {
+  male_val <- calc_ibw(weight = 80, height = 170, age = 40, sex = "male")
+  female_val <- calc_ibw(weight = 80, height = 170, age = 40, sex = "female")
+  vec_val <- calc_ibw(
+    weight = c(80, 80), height = c(170, 170),
+    age = c(40, 40), sex = c("male", "female")
+  )
+  expect_equal(vec_val, c(male_val, female_val))
+})
+
+test_that("calc_ibw() errors on mismatched vector lengths", {
   expect_error(
-    calc_ibw(age = c(10, 20), sex = c("male", "female"), height = 100, 130)
+    calc_ibw(
+      age = c(30, 40),
+      sex = c("male", "female", "male"),
+      height = 170
+    ),
+    "Vector inputs must all be the same length: `age` \\(size 2\\), `sex` \\(size 3\\)\\."
   )
 })
 

--- a/tests/testthat/test_calc_lbw.R
+++ b/tests/testthat/test_calc_lbw.R
@@ -28,3 +28,28 @@ test_that("LBW calculation works, boer", {
     41.4
   )
 })
+
+test_that("vectorization over different sex values works for all methods", {
+  methods <- c("green", "boer", "james", "hume")
+
+  for (m in methods) {
+    male_val <- calc_lbw(method = m, sex = "male", weight = 80, height = 170)$value
+    female_val <- calc_lbw(method = m, sex = "female", weight = 80, height = 170)$value
+    vec_val <- calc_lbw(
+      method = m, sex = c("male", "female"),
+      weight = c(80, 80), height = c(170, 170)
+    )$value
+    expect_equal(vec_val, c(male_val, female_val), label = paste("method:", m))
+  }
+})
+
+test_that("calc_lbw() errors on mismatched vector lengths", {
+  expect_error(
+    calc_lbw(
+      sex = c("male", "female"),
+      weight = c(80, 80, 80),
+      height = 170
+    ),
+    "Vector inputs must all be the same length: `sex` \\(size 2\\), `weight` \\(size 3\\)\\."
+  )
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -104,3 +104,80 @@ test_that("check_input_lengths() errors on mismatched vector lengths", {
     "Vector inputs must all be the same length: `sex` \\(size 2\\), `age` \\(size 3\\), `scr` \\(size 4\\)\\."
   )
 })
+
+# normalize_sex() -------------------------------------------------------------
+test_that("normalize_sex() returns lowercased sex for valid inputs", {
+  expect_equal(normalize_sex("male"),   "male")
+  expect_equal(normalize_sex("female"), "female")
+  expect_equal(normalize_sex("Male"),   "male")
+  expect_equal(normalize_sex("FEMALE"), "female")
+})
+
+test_that("normalize_sex() works on valid vectors", {
+  expect_equal(normalize_sex(c("male", "female")), c("male", "female"))
+  expect_equal(normalize_sex(c("Male", "Female")), c("male", "female"))
+})
+
+test_that("normalize_sex() warns and returns NULL for unsupported values", {
+  expect_warning(
+    res <- normalize_sex("unknown"),
+    "This method requires sex to be one of 'male' or 'female'."
+  )
+  expect_null(res)
+})
+
+test_that("normalize_sex() warns and returns NULL for NULL input", {
+  expect_warning(
+    res <- normalize_sex(NULL),
+    "This method requires sex to be one of 'male' or 'female'."
+  )
+  expect_null(res)
+})
+
+test_that("normalize_sex() warns and returns NULL if any element is unsupported", {
+  expect_warning(
+    res <- normalize_sex(c("male", "unknown")),
+    "This method requires sex to be one of 'male' or 'female'."
+  )
+  expect_null(res)
+})
+
+# prepare_method_inputs() -----------------------------------------------------
+test_that("prepare_method_inputs() returns inputs unchanged when all req args supplied", {
+  result <- prepare_method_inputs(
+    lbw_green, "green", weight = 80, sex = "male", bmi = 25
+  )
+  expect_equal(result$weight, 80)
+  expect_equal(result$sex, "male")
+  expect_equal(result$bmi, 25)
+})
+
+test_that("prepare_method_inputs() auto-computes bmi from height + weight", {
+  result <- prepare_method_inputs(
+    lbw_green, "green", weight = 80, sex = "male", height = 170
+  )
+  expect_false(is.null(result$bmi))
+  expect_equal(result$bmi, calc_bmi(weight = 80, height = 170))
+})
+
+test_that("prepare_method_inputs() errors when bmi cannot be computed", {
+  expect_error(
+    prepare_method_inputs(lbw_green, "green", sex = "male", weight = 80),
+    "Method 'green' requires: bmi or weight and height\\."
+  )
+})
+
+test_that("prepare_method_inputs() errors when a required arg is missing", {
+  expect_error(
+    prepare_method_inputs(lbw_boer, "boer", sex = "male", height = 170),
+    "Method 'boer' requires: weight\\."
+  )
+})
+
+test_that("prepare_method_inputs() passes optional args through untouched", {
+  result <- prepare_method_inputs(
+    lbw_green, "green", weight = 80, sex = "male", bmi = 25, height = 170, age = 30
+  )
+  expect_equal(result$age, 30)
+  expect_equal(result$height, 170)
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -69,3 +69,38 @@ test_that("%<=% handles zero-length input", {
   expect_equal(c(1, 3) %<=% numeric(0), logical(0))
   expect_equal(numeric(0) %<=% 5, logical(0))
 })
+
+# check_input_lengths() -------------------------------------------------------
+test_that("check_input_lengths() passes when all vectors are the same length", {
+  expect_no_error(
+    check_input_lengths(sex = c("male", "female"), age = c(30, 40))
+  )
+})
+
+test_that("check_input_lengths() passes when some inputs are scalar", {
+  expect_no_error(check_input_lengths(sex = c("male", "female"), age = 30))
+})
+
+test_that("check_input_lengths() passes when all inputs are scalar", {
+  expect_no_error(check_input_lengths(sex = "male", age = 30))
+})
+
+test_that("check_input_lengths() passes when some inputs are NULL", {
+  expect_no_error(
+    check_input_lengths(sex = c("male", "female"), age = c(30, 40), bsa = NULL)
+  )
+})
+
+test_that("check_input_lengths() errors on mismatched vector lengths", {
+  expect_error(
+    check_input_lengths(sex = c("male", "female"), age = c(30, 40, 50)),
+    "Vector inputs must all be the same length: `sex` \\(size 2\\), `age` \\(size 3\\)\\."
+  )
+  # Multiple mismatches are caught too:
+  expect_error(
+    check_input_lengths(
+      sex = c("male", "female"), age = c(30, 40, 50), scr = c(0.5, 0.6, 0.7, 0.8)
+    ),
+    "Vector inputs must all be the same length: `sex` \\(size 2\\), `age` \\(size 3\\), `scr` \\(size 4\\)\\."
+  )
+})


### PR DESCRIPTION
We currently don't handle vectorization/recycling nicely in several of our `calc_*` functions, which can lead to unexpected results when certain functions such as `calc_egfr()` are applied over a vector of covariate values (e.g., in a `dplyr::mutate()` call only the first `sex` value would be used, so patients with the opposite sex would get incorrect estimates), or which prevent the use of vectorization without specific workarounds (e.g., `calc_ffm()` only supports vectorization when sex is of length one), or in toto (e.g., `calc_ibw()` has specific guards against vectorization).

This PR improves handling of vectorization/recycling in the following `calc_*` functions to be safer and more consistent:

- `calc_egfr`
- `calc_ffm`
- `calc_ibw` (this function had the most substantive changes; the rest were fairly trivial)
- `calc_lbw`
- `calc_dosing_weight`

We now allow for covariate arguments to accept vectors of equal length or length one for each of these functions, so they can be used for multiple patients at once (e.g., in a NONMEM-style data set). If there are mismatched lengths, the functions will error with an informative message.

All f-tests in our private repos pass with this change.